### PR TITLE
[김미소] - 메인페이지 수입지출내역 구현 중

### DIFF
--- a/assets/icons/check-btn-square.svg
+++ b/assets/icons/check-btn-square.svg
@@ -1,0 +1,4 @@
+<svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="0.333496" y="0.333344" width="13.3333" height="13.3333" rx="3" fill="black"/>
+<path d="M10.3337 5L5.75033 9.44444L3.66699 7.42424" stroke="white" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/global.css
+++ b/global.css
@@ -1,13 +1,18 @@
+body {
+    margin: 0;
+}
+
 .header {
     background-color: #ababab;
     border-bottom: 1px solid #000000;
-    padding: 40px 20% 64px 20%;
+    padding: 40px 273px 64px 273px
 }
 
 .flex-row {
     display: flex;
-    justify-content: space-between;
+    flex-direction: row;
     align-items: center;
+    justify-content: space-between;
 }
 
 .flex-column {
@@ -54,4 +59,47 @@
 
 .month-text {
     font-size: 48px;
+}
+
+/* DailyListBlock */
+.daily-list-block {
+    align-items: center;
+    width: 100%;
+    height: 56px;
+    background-color: #ffffff;
+
+}
+
+.daily-list-block:hover {
+    background-color: #F1F4F8;
+    cursor: pointer;
+}
+
+.daily-list-block-content {
+    width: 400px;
+    text-align: start;
+}
+
+.daily-list-block-payment {
+    width: 104px;
+    text-align: start;
+}
+
+.daily-list-block-price {
+    width: 92px;
+    text-align: end;
+}
+
+/* TagBox */
+.tag-box {
+    display: flex;
+    background-color: aquamarine;
+    height: 56px;
+    width: 92px;
+    align-items: center;
+    justify-content: center;
+}
+
+.tag {
+    font-size: 12px;
 }

--- a/src/components/DailyListBlock/DailyListBlock.js
+++ b/src/components/DailyListBlock/DailyListBlock.js
@@ -1,0 +1,26 @@
+import TagBox from "../TagBox/TagBox.js";
+
+function handleBlockClick() {
+    const blocks = document.querySelectorAll('.daily-list-block');
+    blocks.forEach(block => {
+        block.addEventListener('click', () => {
+            console.log('DailyListBlock clicked');
+        });
+    });
+}
+
+function DailyListBlock() {
+    return {
+        element: `
+            <div class="daily-list-block">
+                ${TagBox({ value: '식비' }).element}
+                <span class="daily-list-block-content inline-block">점심</span>
+                <span class="daily-list-block-payment inline-block">카드</span>
+                <span class="daily-list-block-price inline-block">1,300원</span>
+            </div>
+        `,
+        init: handleBlockClick
+    };
+}
+
+export default DailyListBlock;

--- a/src/components/DropDown/DropDown.js
+++ b/src/components/DropDown/DropDown.js
@@ -6,6 +6,7 @@ function DropDown({ options, editable, id }) {
             <select class="category-field" id="${id}">
                 <option value="" disabled selected>선택하세요.</option>
                 ${options.map(option => DropDownBlock({ id: option, value: option, editable }).element).join('')}
+                ${editable ? `<option value="기타">추가하기</option>` : ''}
             </select>
         `
     }

--- a/src/components/TagBox/TagBox.js
+++ b/src/components/TagBox/TagBox.js
@@ -1,0 +1,11 @@
+function TagBox({ value }) {
+    return {
+        element: `
+            <div class="tag-box">
+                <span class="tag">${value}</span>
+            </div>
+        `
+    };
+}
+
+export default TagBox;

--- a/src/pages/MainPage/MainPage.css
+++ b/src/pages/MainPage/MainPage.css
@@ -1,11 +1,11 @@
 .main-page {
-    margin: 0 20%;
-    background-color: pink;
+    margin: 0 273px;
 }
 
-.input-bar{
+.input-bar {
     background-color: #ffffff;
     border: 0.5px solid #000000;
+    z-index: 1;
     transform: translate(0, -50%);
     display: flex;
     justify-content: space-between;
@@ -18,7 +18,7 @@
     font-weight: 300;
     font-size: 12px;
     margin-bottom: 4px;
-    height: 24px    ;
+    height: 24px;
 }
 
 .input-bar input {
@@ -42,7 +42,7 @@
 }
 
 .border-line {
-    background-color:#000000;
+    background-color: #000000;
     width: 0.5px;
     height: 100%;
 }
@@ -50,4 +50,30 @@
 .sign-button {
     width: 16px;
     height: 16px;
+}
+
+.main-page-body {
+    padding: 0 24px;
+    background-color: #FFC0CB;
+}
+
+/* Daily List Styles */
+.daily-list {
+    margin-top: 40px;
+    border: 2px solid #4c88ef;
+}
+
+.daily-list-content {
+    margin-top: 16px;
+}
+
+.daily-list-content {
+    border-top: 0.5px solid #000000;
+    border-bottom: 0.5px solid #000000;
+}
+
+.daily-list-block {
+    display: flex;
+    align-items: center;
+    /* 필요에 따라 조정 가능 */
 }

--- a/src/pages/MainPage/MainPage.js
+++ b/src/pages/MainPage/MainPage.js
@@ -1,17 +1,50 @@
 import { loadCSS } from '../../utils/cssLoader.js';
 import InputBar from './components/InputBar.js';
+import DailyList from './components/DailyList.js';
 
 function MainPage() {
     // MainPage CSS 로드
     loadCSS('./src/pages/MainPage/MainPage.css', 'mainpage-css');
 
-    const inputBar = InputBar();
+    const handleFormSubmit = (formData) => {
+        console.log('Received formData in MainPage:', formData);
+        dailyListArray.push(formData);
+    };
+
+    const inputBar = InputBar(handleFormSubmit);
+
+    const dailyListArray = [];
 
     return {
         element: `
             <div class="main-page">
                ${inputBar.element}
-               <h1>가계부</h1>
+               <div class="main-page-body">
+                   <div>
+                       <div class="inline-block">
+                        <span>전체 내역</span>
+                        <span> 13건</span>
+                       </div>
+                        <div>
+                            <button class="icon-button">
+                                <img src="assets/icons/check-btn-square.svg" alt="plus icon">
+                            </button>
+                            <span class="income-text">수입</span>
+                            <span class="income-amount">1,000,000원</span
+                        </div>
+                        <div>
+                            <button class="icon-button">
+                                <img src="assets/icons/check-btn-square.svg" alt="minus icon">
+                            </button>
+                            <span class="expense-text">지출</span>
+                            <span class="expense-amount">500,000원</span>
+                        </div>
+                    </div>
+                    <div class="daily-list-container">
+                        ${DailyList({ dailyListArray: dailyListArray }).element}
+                        ${DailyList({ dailyListArray: dailyListArray }).element}
+                    </div>
+                </div>
             </div>
         `,
         init: () => {
@@ -19,6 +52,11 @@ function MainPage() {
             if (inputBar.init) {
                 inputBar.init();
             }
+            // DailyList 초기화
+            if (DailyList({ dailyListArray: dailyListArray }).init) {
+                DailyList({ dailyListArray: dailyListArray }).init();
+            }
+
         }
     }
 }

--- a/src/pages/MainPage/components/DailyList.js
+++ b/src/pages/MainPage/components/DailyList.js
@@ -1,0 +1,26 @@
+import DailyListBlock from "../../../components/DailyListBlock/DailyListBlock.js";
+
+function DailyList({ dailyListArray }) {
+
+    return {
+        element: `
+            <div class="daily-list">
+                <div class="flex-row">
+                    <div class="date-text">2023년 8월 1일</div>
+                    <div class="inline-block">
+                        <span>지출</span>
+                        <span> 1,300원</span>
+                    </div>
+                </div>
+                <div class="daily-list-content">
+                    ${DailyListBlock().element}
+                </div>
+            </div>
+        `
+        ,
+        init: () => {
+            DailyListBlock().init();
+        }
+    };
+}
+export default DailyList;

--- a/src/pages/MainPage/components/InputBar.js
+++ b/src/pages/MainPage/components/InputBar.js
@@ -1,12 +1,14 @@
 import DropDown from '../../../components/DropDown/DropDown.js';
 
-function InputBar() {
-    const pluscCategoryList = [
-        '월급', '용돈', '기타 수입'
-    ];
-    const minusCategoryList = [
-        '생활', '식비', '교통', '쇼핑/뷰티', '의료/건강', '문화/건강', '미분류'
-    ];
+const pluscCategoryList = [
+    '월급', '용돈', '기타 수입'
+];
+const minusCategoryList = [
+    '생활', '식비', '교통', '쇼핑/뷰티', '의료/건강', '문화/건강', '미분류'
+];
+
+function InputBar(onSubmitCallback) {
+    const paymentOptions = ['카드', '현금', '계좌이체', '기타'];
 
     let isPlus = false;
 
@@ -37,8 +39,10 @@ function InputBar() {
         updateCategoryOptions();
     };
 
+
+
     const validateInputs = () => {
-        const dateInput = document.querySelector('.input-field input');
+        const dateInput = document.getElementById('date-select');
         const amountInput = document.querySelector('.amount-field');
         const contentInput = document.querySelector('.content-field');
         const paymentSelect = document.getElementById('payment-field');
@@ -59,8 +63,10 @@ function InputBar() {
             checkButton.disabled = !isValid; // 체크 버튼 활성화/비활성화
             if (isValid) {
                 checkButton.classList.remove('disabled');
+                checkButton.style.cursor = 'pointer';
             } else {
                 checkButton.classList.add('disabled');
+                checkButton.style.cursor = 'not-allowed';
             }
             const img = checkButton.querySelector('img');
 
@@ -71,12 +77,35 @@ function InputBar() {
         else console.error('Check button not found');
     };
 
+    const handleSubmit = () => {
+        const dateInput = document.getElementById('date-select');
+        const amountInput = document.querySelector('.amount-field');
+        const contentInput = document.querySelector('.content-field');
+        const paymentSelect = document.getElementById('payment-field');
+        const categorySelect = document.getElementById('category-select');
+
+        const formData = {
+            date: dateInput.value,
+            amount: amountInput.value,
+            content: contentInput.value,
+            payment: paymentSelect.value,
+            category: categorySelect.value
+        };
+
+        console.log('Form submitted:', formData);
+
+        // MainPage로 formData 전달
+        if (onSubmitCallback) {
+            onSubmitCallback(formData);
+        }
+    };
+
     return {
         element: `
             <div class="input-bar">
                 <div class="flex-column input-field">
                     <label>일자</label>
-                    <input type="text" placeholder="항목을 입력하세요">
+                    <input type="date" id='date-select'>
                 </div>
                 <div class="border-line"></div>
                 <div class="flex-column">
@@ -85,7 +114,7 @@ function InputBar() {
                         <button class="icon-button sign-button" id="plus-minus-btn">
                             <img src="assets/icons/minus.svg" alt="minus icon">
                         </button>
-                        <input type="number" class="amount-field" placeholder="0">
+                        <input type="text" class="amount-field" placeholder="0">
                         <span>원</span>
                     </div>
                 </div>
@@ -101,7 +130,7 @@ function InputBar() {
                 <div class="flex-column">
                     <label>결제 수단</label>
                     ${DropDown({
-            options: ['카드', '현금', '계좌이체', '기타'],
+            options: paymentOptions,
             id: 'payment-field',
             editable: true
         }).element}
@@ -109,23 +138,20 @@ function InputBar() {
                 <div class="border-line"></div>
                 <div class="flex-column">
                     <label>분류</label>
-                    <select id="category-select">
-                        <option value="" disabled selected>선택하세요.</option>
-                        <option value="생활">생활</option>
-                        <option value="식비">식비</option>
-                        <option value="교통">교통</option>
-                        <option value="쇼핑/뷰티">쇼핑/뷰티</option>
-                        <option value="의료/건강">의료/건강</option>
-                        <option value="문화/건강">문화/건강</option>
-                        <option value="미분류">미분류</option>
-                    </select>
+                    ${DropDown({
+            options: isPlus ? pluscCategoryList : minusCategoryList,
+            id: 'category-select',
+            editable: false
+        }).element}
                 </div>
                 <button class="icon-button" id="submit-btn">
-                    <img src="/assets/icons/check-button.svg" alt="check icon" id="check-icon">
+                    <img src="assets/icons/check-button.svg" alt="check icon" id="check-icon">
                 </button>
             </div>
         `,
         init: () => {
+            document.getElementById('date-select').value = new Date().toISOString().substring(0, 10);
+
             // DOM이 렌더링된 후에 이벤트 리스너 등록
             const plusMinusBtn = document.getElementById('plus-minus-btn');
             if (plusMinusBtn) {
@@ -143,6 +169,15 @@ function InputBar() {
 
             // 초기 체크 버튼 상태 설정
             validateInputs();
+
+            const checkButton = document.getElementById('submit-btn');
+            if (checkButton) {
+                checkButton.addEventListener('click', () => {
+                    if (!checkButton.classList.contains('disabled')) {
+                        handleSubmit();
+                    }
+                });
+            }
         }
     }
 }


### PR DESCRIPTION
## 완료 작업 목록
### TagBox 컴포넌트 분리
- 메인페이지 뿐만 아니라 통계 페이지에서도 사용되는 것 같기에 분리해두면 후에 재사용하기 용이할 것 같다.
- 내용에 해당하는 `value`만 파라미터로 넘겨주도록

### 입력 데이터 전달
- 분리해둔 `InputBar`에서 받은 데이터를 메인페이지에 넘기도록 콜백 함수 `handleFormSubmit`를 파라미터로 넘겨줌
- `InputBar`에서 `handleSubmit` 함수 안에서 `onSubmitCallback` 실행
- **그런데 관련해서 고민해봐야할 부분이**
- 반대로 메인페이지 -> `InputBar`로 formData를 전달해야 할 때도 있는데 어떤 식으로 하게 될지 아직 모르겠다..

### 일별 수입지출내역 컴포넌트화

## 주요 고민과 해결 과정
### [분류] 드롭다운 옵션 전달
- 컴포넌트를 사용하고 있기 때문에 기존의 파라미터로 리스트를 넘겨줄 때에 isPlus 값에 따라 달리 하려함
- **문제**:
  - 알고보니 다른 함수에서 innerHTML이 실행되는 것 때문이었다.
  - 추후에 다시 해결해봐야 할 것 같다..
 
### 가로 배치
- 어제의 PR에서도 언급한 내용인데 수입지출내역의 헤더 부분에서 텍스트들을 가로로 배치하는데에 문제가 생겼다.
- `display: flex`를 사용하면서 다른 스타일과 충돌이 생기는 것 같다.
- 영향이 미치는 다른 부분들에 대해서도 제대로 파악해보아야 할 것 같다..