### PR TITLE
[유재민] - 내역 렌더링 및 항목 추가 구현, 헤더와 데이터 연결

### DIFF
--- a/assets/header.css
+++ b/assets/header.css
@@ -1,4 +1,4 @@
-header {
+.page-header {
   display: flex;
   background-color: var(--colorchip-80);
   width: 100%;

--- a/assets/main.css
+++ b/assets/main.css
@@ -107,9 +107,115 @@
   width: 104px;
 }
 
-.record-container {
+.records-container {
   display: flex;
   flex-direction: column;
   width: 850px;
-  border: 0.5px solid var(--neutral-border-default);
+  gap: 40px;
+}
+
+.total-amount {
+  display: flex;
+  align-items: center;
+}
+.total-count {
+  margin-right: 8px;
+}
+.total-income {
+  margin-left: auto;
+  margin-right: 12px;
+}
+.total-outcome {
+  margin-right: 0;
+}
+.record-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-bottom: 16px;
+  border-bottom: 0.5px solid var(--neutral-border-default);
+}
+.record-main {
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+}
+
+.record-container > div:last-child {
+  border-bottom: 0.5px solid var(--neutral-border-default);
+}
+
+.records-container > button {
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+}
+.record-item {
+  display: flex;
+  height: 56px;
+  align-items: center;
+  justify-content: center;
+}
+
+.record-item > div {
+  display: flex;
+  margin-right: 16px;
+}
+
+.category {
+  width: 92px;
+  height: 100%;
+  align-items: center;
+  justify-content: center;
+  background-color: var(--pastel-perfume);
+}
+.description {
+  flex: 1;
+}
+
+.payment {
+  width: 104px;
+}
+.amount {
+  width: 180px;
+  justify-content: flex-end;
+}
+
+.amount.minus {
+  color: var(--brand-text-expense);
+}
+
+.amount.plus {
+  color: var(--brand-text-income);
+}
+
+.record-item .category.생활 {
+  background-color: var(--colorchip-90);
+}
+
+.record-item .category.식비 {
+  background-color: var(--colorchip-60);
+}
+
+.record-item .category.교통 {
+  background-color: var(--colorchip-70);
+}
+
+.record-item .category.쇼핑\/뷰티 {
+  background-color: var(--colorchip-30);
+}
+
+.record-item .category.의료\/건강 {
+  background-color: var(--colorchip-50);
+}
+
+.record-item .category.문화\/여가 {
+  background-color: var(--pastel-perfume);
+}
+
+.record-item .category.미분류 {
+  background-color: var(--pastel-lavenderPink);
 }

--- a/components/header.html
+++ b/components/header.html
@@ -1,4 +1,4 @@
-<header>
+<header class="page-header">
   <div class="header-container">
     <a href="#main" class="logo">Wise Wallet</a>
     <div class="date-selector">

--- a/pages/main.html
+++ b/pages/main.html
@@ -59,5 +59,17 @@
   </div>
 
   <!-- 가계부 내역 렌더링 -->
-  <div class="record-container">여기에 기록 표시</div>
+  <div class="records-container">
+    <header class="total-amount">
+      <p class="font-light-12 total-count">전체 내역</p>
+      <p class="font-light-12 count">13건</p>
+
+      <div class="font-light-12 total-income"><button class="income-filter"></button>수입</div>
+
+      <div class="font-light-12 total-outcome"><button class="outcome-filter"></button>지출</div>
+    </header>
+    <main class="record-main">
+      <!-- 여기에 동적으로 렌더링 -->
+    </main>
+  </div>
 </div>

--- a/scripts/elements.js
+++ b/scripts/elements.js
@@ -1,4 +1,5 @@
 export const elements = {
+  headerEl: () => document.getElementById("header"),
   dateInputEl: () => document.querySelector(".date-input"),
   toggleButtonEl: () => document.querySelector(".toggle-button"),
   valueInputEl: () => document.querySelector(".value-number"),
@@ -9,4 +10,7 @@ export const elements = {
   paymentArrowIconEl: () => document.querySelector(".payment-arrow-icon"),
   submitButtonEl: () => document.querySelector(".submit-button"),
   checkBoxEl: () => document.querySelector(".checkbox"),
+  recordContainerEl: () => document.querySelector(".record-main"),
+  incomeFilterButtonEl: () => document.querySelector(".income-filter"),
+  outcomeFilterButtonEl: () => document.querySelector(".outcome-filter"),
 };

--- a/scripts/header.js
+++ b/scripts/header.js
@@ -1,49 +1,63 @@
+export async function loadHeaderHTML() {
+  const headerEl = document.getElementById("header");
+  const res = await fetch("./components/header.html");
+  const html = await res.text();
+  headerEl.innerHTML = html;
+}
+
 export function initializeHeader() {
+  const headerEl = document.querySelector("header");
 
-const headerEl = document.querySelector('header');
+  const prevBtn = headerEl.querySelector(".prev-month");
+  const nextBtn = headerEl.querySelector(".next-month");
+  const yearEl = headerEl.querySelector(".year");
+  const monthEl = headerEl.querySelector(".month");
+  const monthEnEl = headerEl.querySelector(".month-en");
 
-const prevBtn = headerEl.querySelector('.prev-month');
-const nextBtn = headerEl.querySelector('.next-month');
-const yearEl = headerEl.querySelector('.year');
-const monthEl = headerEl.querySelector('.month');
-const monthEnEl = headerEl.querySelector('.month-en');
+  let currentYear = yearEl.textContent;
+  let currentMonth = monthEl.textContent;
+  console.log("initial value: ", currentYear, currentMonth);
+  const monthNames = [
+    "",
+    "January",
+    "February",
+    "March",
+    "April",
+    "May",
+    "June",
+    "July",
+    "August",
+    "September",
+    "October",
+    "November",
+    "December",
+  ];
 
-
-let currentYear = yearEl.textContent;
-let currentMonth = monthEl.textContent;
-console.log("initial value: ", currentYear, currentMonth);
-const monthNames = ["",
-    'January', 'February', 'March', 'April', 'May', 'June',
-    'July', 'August', 'September', 'October', 'November', 'December'
-];
-
-function updateDisplay() {
+  function updateDisplay() {
     yearEl.textContent = currentYear;
     monthEl.textContent = currentMonth;
     monthEnEl.textContent = monthNames[currentMonth];
-}
+  }
 
-prevBtn.addEventListener('click', () => {
+  prevBtn.addEventListener("click", () => {
     if (currentMonth === 1) {
-        currentMonth = 12;
-        currentYear--;
-    }
-    else {
-        currentMonth--;
+      currentMonth = 12;
+      currentYear--;
+    } else {
+      currentMonth--;
     }
 
-    console.log("prevBtn clicked", currentMonth, currentYear);
     updateDisplay();
-})
+  });
 
-nextBtn.addEventListener('click', () => {
-    if( currentMonth === 12) {
-        currentMonth = 1;
-        currentYear++;
+  nextBtn.addEventListener("click", () => {
+    if (currentMonth === 12) {
+      currentMonth = 1;
+      currentYear++;
+    } else {
+      currentMonth++;
     }
-    else{
-        currentMonth++;
-    }
-    console.log("nextBtn clicked", currentMonth, currentYear);
+
     updateDisplay();
-})}
+  });
+}

--- a/scripts/header.js
+++ b/scripts/header.js
@@ -1,5 +1,8 @@
+import { records, renderRecords } from "./records.js";
+import { elements } from "./elements.js";
+
 export async function loadHeaderHTML() {
-  const headerEl = document.getElementById("header");
+  const headerEl = elements.headerEl();
   const res = await fetch("./components/header.html");
   const html = await res.text();
   headerEl.innerHTML = html;
@@ -16,7 +19,6 @@ export function initializeHeader() {
 
   let currentYear = yearEl.textContent;
   let currentMonth = monthEl.textContent;
-  console.log("initial value: ", currentYear, currentMonth);
   const monthNames = [
     "",
     "January",
@@ -48,6 +50,7 @@ export function initializeHeader() {
     }
 
     updateDisplay();
+    renderRecords(currentYear, currentMonth, records);
   });
 
   nextBtn.addEventListener("click", () => {
@@ -59,5 +62,6 @@ export function initializeHeader() {
     }
 
     updateDisplay();
+    renderRecords(currentYear, currentMonth, records);
   });
 }

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -1,5 +1,5 @@
 import { loadPage } from "./router.js";
-import { initializeHeader } from "./header.js";
+import { loadHeaderHTML, initializeHeader } from "./header.js";
 import {
   initToggleButton,
   getInputValues,
@@ -9,11 +9,11 @@ import {
 } from "./input.js";
 
 window.addEventListener("DOMContentLoaded", async () => {
-  const headerEl = document.getElementById("header");
-  const res = await fetch("./components/header.html");
-  const html = await res.text();
-  headerEl.innerHTML = html;
+  // 헤더 html 로딩 후 초기화
+  await loadHeaderHTML();
   initializeHeader();
+
+  // 해시 값 별 각 페이지 로딩 후 초기화
   await loadPage();
   initToggleButton();
   initCategoryDropdown();

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -7,6 +7,7 @@ import {
   initCategoryDropdown,
   initInputChanges,
 } from "./input.js";
+import { records, renderRecords, renderRecordByDate, getFormattedDate } from "./records.js";
 
 window.addEventListener("DOMContentLoaded", async () => {
   // 헤더 html 로딩 후 초기화
@@ -20,6 +21,8 @@ window.addEventListener("DOMContentLoaded", async () => {
   initPaymentDropdown();
   initInputChanges();
   getInputValues();
+
+  renderRecords(records);
 });
 
 window.addEventListener("hashchange", loadPage);

--- a/scripts/input.js
+++ b/scripts/input.js
@@ -1,6 +1,7 @@
 // input 바에서 사용하는 드롭다운, 유효성 검증, 글자수 세기 등의 로직을 다루는 파일
 
 import { elements } from "./elements.js";
+import { addRecord } from "./records.js";
 
 let valueSign = "minus"; // or "plus"
 let paymentOptions = ["현금", "신용카드", "추가하기"];
@@ -12,7 +13,6 @@ const categoryOptions = {
 export const initToggleButton = () => {
   const toggleButtonEl = elements.toggleButtonEl();
   toggleButtonEl.addEventListener("click", () => {
-    console.log("Toggle button clicked");
     const currentSign = toggleButtonEl.textContent.trim();
     if (currentSign === "+") {
       toggleButtonEl.textContent = "-";
@@ -56,7 +56,6 @@ export const initDropdown = ({
   function toggleDropdown(e) {
     e.stopPropagation();
     const isOpen = optionsUl.style.display === "block";
-    console.log(isOpen);
     if (isOpen) {
       optionsUl.setAttribute("style", "display: none");
     } else {
@@ -166,7 +165,7 @@ export const getInputValues = () => {
     const payment = elements.paymentCellEl().textContent.trim();
     const category = elements.categoryCellEl().textContent.trim();
 
-    console.log("Input Values:", {
+    addRecord({
       date,
       sign,
       value,
@@ -174,14 +173,5 @@ export const getInputValues = () => {
       payment,
       category,
     });
-
-    return {
-      date,
-      sign,
-      value,
-      description,
-      payment,
-      category,
-    };
   });
 };

--- a/scripts/records.js
+++ b/scripts/records.js
@@ -1,0 +1,194 @@
+// 입력받은 정보를 토대로 삽입 / 수정 / 삭제 기능을 담당하는 함수들을 다루는 파일
+import { elements } from "./elements.js";
+
+export const records = [
+  {
+    date: "2025-08-14",
+    items: [
+      {
+        category: "문화/여가",
+        description: "스트리밍 서비스 정기 결제",
+        payment: "현대카드",
+        amount: -10900,
+      },
+      {
+        category: "교통",
+        description: "후불 교통비 결제",
+        payment: "현대카드",
+        amount: -45340,
+      },
+    ],
+  },
+  {
+    date: "2025-08-13",
+    items: [
+      {
+        category: "미분류",
+        description: "온라인 세미나 신청",
+        payment: "현대카드",
+        amount: -10000,
+      },
+    ],
+  },
+  {
+    date: "2025-08-10",
+    items: [
+      {
+        category: "식비",
+        description: "잔치국수와 김밥",
+        payment: "현대카드",
+        amount: -9500,
+      },
+      {
+        category: "월급",
+        description: "8월 급여",
+        payment: "현금",
+        amount: 2010580,
+      },
+    ],
+  },
+];
+
+// records 배열의 각 날짜별로 section을 만드는 함수
+export const renderRecords = (currentYear, currentMonth, records) => {
+  // 이전 렌더링 초기화
+  const recordContainerEl = elements.recordContainerEl();
+  recordContainerEl.innerHTML = "";
+
+  // 현재 헤더의 날짜에 해당하는 date값만 함수 호출
+  records.forEach((record) => {
+    const date = record.date;
+    //"YYYY-MM-DD" 에서 YYYY와 MM 추출 후 헤더의 날짜와 비교해서 같은 값만 호출
+    let year = date.split("-")[0];
+    let month = date.split("-")[1];
+    const items = record.items;
+    if (Number(currentYear) === Number(year) && Number(currentMonth) === Number(month)) {
+      renderRecordByDate({ date, items });
+    }
+  });
+};
+
+// 날짜와 데이터를 받아와서 섹션을 렌더링
+export const renderRecordByDate = ({ date, items }) => {
+  const formattedDate = getFormattedDate(date);
+  const recordsHTML = generateRecordHTML(items);
+
+  // 해당 날짜의 총 지출/수입을 구하기 위한 코드
+  const { income, outcome } = getTotalAmount(items);
+  let incomeContent = "";
+  let outcomeContent = "";
+  if (income !== 0) incomeContent = `수입 ${formatWithComma(income)}원`;
+  if (outcome !== 0) outcomeContent = `지출 ${formatWithComma(outcome)}원`;
+
+  const recordContainerEl = elements.recordContainerEl();
+  recordContainerEl.innerHTML += `
+    <div class="record-container">
+      <div class="record-header">
+        <div class="record-date">${formattedDate}</div>
+        <div class="record-amount">${incomeContent}  ${outcomeContent}</div>
+      </div> ${recordsHTML}
+    <div>
+  `;
+};
+
+// 아이템 배열을 순회하며 html태그로 만들어주는 함수
+export const generateRecordHTML = (items) => {
+  let itemsHTML = "";
+  let sign = "minus"; // or "plus", 금액의 지출/수입 여부
+  items.forEach((item) => {
+    if (item.amount < 0) {
+      sign = "minus";
+    } else {
+      sign = "plus";
+    }
+    itemsHTML += `
+      <div class="record-item">
+        <div class="category ${item.category}">${item.category}</div>
+        <div class="description">${item.description}</div>
+        <div class="payment">${item.payment}</div>
+        <div class="amount ${sign}">${formatWithComma(item.amount)}</div>
+      </div>`;
+  });
+  return itemsHTML;
+};
+
+// 날짜 데이터를 출력 포맷으로 바꿔주는 함수
+export const getFormattedDate = (dateStr) => {
+  const date = new Date(dateStr);
+  const month = date.getMonth() + 1;
+  const day = date.getDate();
+  const dayIndex = date.getDay();
+
+  const koreanDayNames = ["일요일", "월요일", "화요일", "수요일", "목요일", "금요일", "토요일"];
+
+  return `${month}월 ${day}일 ${koreanDayNames[dayIndex]}`;
+};
+
+// 숫자 데이터에 3자리마다 쉼표(,) 추가하는 함수
+export const formatWithComma = (num) => {
+  if (typeof num === "number") num = String(num);
+  return num.replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+};
+
+// 날짜 별 수입, 지출의 합을 구해주는 함수
+export const getTotalAmount = (items) => {
+  let income = 0;
+  let outcome = 0;
+
+  items.forEach((item) => {
+    if (item.amount < 0) {
+      outcome += Math.abs(item.amount);
+    } else {
+      income += item.amount;
+    }
+  });
+
+  return { income, outcome };
+};
+
+export const addRecord = ({ date, sign, value, description, payment, category }) => {
+  // 부호 처리
+  let amount = sign + value;
+
+  // record에 추가하려는 날짜에 대한 정보가 이미 있나 확인
+  const foundRecord = records.find((record) => record.date === date);
+
+  if (foundRecord) {
+    // 이미 있는 날짜 처리
+    foundRecord.items.push({
+      category,
+      description,
+      payment,
+      amount,
+    });
+  } else {
+    // 없는 날짜라면 record에 날짜 포함 객체 생성
+    records.push({
+      date,
+      items: [{ category, description, payment, amount }],
+    });
+  }
+
+  // 이후 다시 렌더링
+  const headerEl = elements.headerEl();
+  const yearEl = headerEl.querySelector(".year");
+  const monthEl = headerEl.querySelector(".month");
+  renderRecords(yearEl.textContent, monthEl.textContent, records);
+};
+
+// 전체 내역 수입 지출 필터링
+const toggleRecordVisibility = (type, isChecked) => {
+  // type = "income" | "outcome"
+  const visibleButtonEl = "";
+  if (type === income) {
+    visibleButtonEl = elements.incomeFilterButtonEl();
+  } else {
+    visibleButtonEl = elements.outcomeFilterButtonEl();
+  }
+
+  if (isChecked) {
+    // check 상태였다면 토글 후 필터링
+    isChecked = false;
+    // 필터링을 어케함 ???
+  }
+};

--- a/scripts/records.js
+++ b/scripts/records.js
@@ -87,7 +87,7 @@ export const renderRecordByDate = ({ date, items }) => {
         <div class="record-date">${formattedDate}</div>
         <div class="record-amount">${incomeContent}  ${outcomeContent}</div>
       </div> ${recordsHTML}
-    <div>
+    </div>
   `;
 };
 


### PR DESCRIPTION


https://github.com/user-attachments/assets/f570d066-0527-409e-9949-890c2d030424




## 완료 작업 목록
1. 목데이터를 이용해서 월별 내역이 렌더링되도록 구현
2. 헤더의 날짜 데이터를 아래 메인 부분에서도 가져와서, 헤더 날짜가 변경될 때 렌더링되는 데이터가 달라지도록 작업
3. 유효성 검증이 완료되어 폼 제출을 하면 해당 날짜에 내역이 추가되도록 구현


## 주요 고민과 해결 과정
1. 헤더의 날짜에 해당하는 데이터만 렌더링되게 하려면 어떻게 해야할까?
-> 배열의 날짜 정보("YYYY-MM-DD")를 연도와 개월 데이터로 분리해서, 헤더 html의 year, month 요소와 값을 비교한다. 이후 해당 날짜에 대한 배열만 세부 렌더링 함수에 매개변수로 넘겨준다.
```js
records.forEach((record) => {
    const date = record.date;
    //"YYYY-MM-DD" 에서 YYYY와 MM 추출 후 헤더의 날짜와 비교해서 같은 값만 호출
    let year = date.split("-")[0];
    let month = date.split("-")[1];
    if (Number(currentYear) === Number(year) && Number(currentMonth) === Number(month)) {
        renderRecordByDate({ date, items }); // 개별 레코드 렌더링 함수
    }
}
```

2. 헤더에서 날짜를 변경할 때, 이전 내역들이 지워지지 않고 그 위에 추가적으로 변경된 날짜의 내역들이 렌더링 되는 문제
-> 내역을 보여주는 함수의 초반에 innerHTML을 초기화해주는 코드를 추가하여 새로 렌더링되도록 하였다.
```js
// 이전 렌더링 초기화
  const recordContainerEl = elements.recordContainerEl();
  recordContainerEl.innerHTML = "";
```

3. (진행중) 전체 지출/수입 내역 필터링 구현 방식에 대한 고민
-> 버튼을 누를 때마다 렌더링이 되도록 해야하는데, 추가적으로 렌더링 함수를 구현하고 싶진 않았다. 따라서 기존 함수에 매개변수를 추가하는 방법을 생각해냈다. filter 매개변수를 두고 해당 값에 따라 한 번 필터링 후 개별 레코드 렌더링 함수를 호출해서 구현할 예정이다.