### PR TITLE
[시보성] - 월별 리렌더링 및 수입/지출 필터 기능 완료

### DIFF
--- a/components/dailyList/daily.js
+++ b/components/dailyList/daily.js
@@ -1,4 +1,5 @@
 import { createElement } from '../../../utils.js';
+import { formatAmount } from '../../utils.js';
 const COLOR = {
     생활: '#A7B9E9',
     '문화/여가': '#BDA6E1',
@@ -16,12 +17,16 @@ export default function createDaily(dailyInfo) {
     const { category, description, payment, amount } = dailyInfo;
 
     const dailyInnerHtml = `
-            <div class="category-info lt-14" style="background-color :${COLOR[category]}" >${category}</div>
+            <div class="category-info lt-14" style="background-color :${
+                COLOR[category]
+            }" >${category}</div>
             <div class="description-info lt-14">
                 ${description}
             </div>
             <div class="payment-info lt-14">${payment}</div>
-            <div class="amount-info lt-14">${amount}</div>
+            <div class="amount-info ${
+                amount > 0 ? 'text-blue' : 'text-red'
+            } lt-14">${formatAmount(amount)}원</div>
         `;
 
     const $dailyInfo = createElement(

--- a/components/dailyList/dailyList.js
+++ b/components/dailyList/dailyList.js
@@ -38,8 +38,8 @@ export default function createDaliyList(dailyInfo) {
     });
 
     let amountHtml = '';
-    amountHtml += totalIncome != 0 ? `<div>수입 ${totalIncome}<div>` : '';
-    amountHtml += totalExpense != 0 ? `<div>지출 ${totalExpense}<div>` : '';
+    amountHtml += totalIncome != 0 ? `<div>수입 ${totalIncome}</div>` : '';
+    amountHtml += totalExpense != 0 ? `<div>지출 ${totalExpense}</div>` : '';
 
     const $dailyAmount = createElement(
         'div',

--- a/components/dailyList/dailyList.js
+++ b/components/dailyList/dailyList.js
@@ -29,7 +29,6 @@ export default function createDaliyList(dailyInfo) {
 
     dailyInfo.items.forEach((info) => {
         $dailyListWrapper.appendChild(createDaily(info));
-        console.log(info);
         if (info.amount > 0) {
             totalIncome += info.amount;
         } else {

--- a/components/dailyList/dailyList.js
+++ b/components/dailyList/dailyList.js
@@ -1,3 +1,4 @@
+import { dailyData } from '../../store/daily.js';
 import {
     createElement,
     formatAmount,
@@ -31,23 +32,35 @@ export default function createDaliyList(dailyInfo) {
     let totalIncome = 0;
     let totalExpense = 0;
 
+    let totalcnt = 0;
+
     dailyInfo.items.forEach((info) => {
-        $dailyListWrapper.appendChild(createDaily(info));
-        if (info.amount > 0) {
-            totalIncome += info.amount;
-        } else {
-            totalExpense -= info.amount;
+        if (
+            (!dailyData.filteredIncome && info.amount > 0) ||
+            (!dailyData.filteredExpense && info.amount < 0)
+        ) {
+            totalcnt++;
+            if (info.amount > 0) {
+                totalIncome += info.amount;
+                dailyData.totalIncome += info.amount;
+            } else {
+                totalExpense -= info.amount;
+                dailyData.totalExpense -= info.amount;
+            }
+            $dailyListWrapper.appendChild(createDaily(info));
         }
     });
 
     let amountHtml = '';
     amountHtml +=
-        totalIncome != 0 ? `<div>수입 ${formatAmount(totalIncome)}</div>` : '';
+        totalIncome != 0
+            ? `<div>수입 ${formatAmount(totalIncome)}원</div>`
+            : '';
     amountHtml +=
         totalExpense != 0
             ? `<div class="amount-line">지출 ${formatAmount(
                   totalExpense,
-              )}</div>`
+              )}원</div>`
             : '';
 
     const $dailyAmount = createElement(
@@ -58,5 +71,6 @@ export default function createDaliyList(dailyInfo) {
 
     $dailyListContainer.querySelector('.date-info').after($dailyAmount);
 
+    if (totalcnt == 0) return null;
     return $dailyListContainer;
 }

--- a/components/dailyList/dailyList.js
+++ b/components/dailyList/dailyList.js
@@ -1,4 +1,8 @@
-import { createElement, formatDateToKorean } from '../../utils.js';
+import {
+    createElement,
+    formatAmount,
+    formatDateToKorean,
+} from '../../utils.js';
 import createDaily from './daily.js';
 
 export default function createDaliyList(dailyInfo) {
@@ -37,8 +41,14 @@ export default function createDaliyList(dailyInfo) {
     });
 
     let amountHtml = '';
-    amountHtml += totalIncome != 0 ? `<div>수입 ${totalIncome}</div>` : '';
-    amountHtml += totalExpense != 0 ? `<div>지출 ${totalExpense}</div>` : '';
+    amountHtml +=
+        totalIncome != 0 ? `<div>수입 ${formatAmount(totalIncome)}</div>` : '';
+    amountHtml +=
+        totalExpense != 0
+            ? `<div class="amount-line">지출 ${formatAmount(
+                  totalExpense,
+              )}</div>`
+            : '';
 
     const $dailyAmount = createElement(
         'div',

--- a/components/dailyList/index.css
+++ b/components/dailyList/index.css
@@ -10,8 +10,8 @@
 }
 
 .daliy-line-wrapper {
-    border-top: 1px solid #000000;
-    border-bottom: 1px solid #000000;
+    border-top: 1px solid var(--grayscale-400);
+    border-bottom: 1px solid var(--grayscale-400);
 }
 
 .category-info {

--- a/components/dailyList/index.css
+++ b/components/dailyList/index.css
@@ -49,3 +49,35 @@
     justify-content: space-between;
     font-size: 14px;
 }
+
+.total-header {
+    display: flex;
+    justify-content: space-between;
+    margin-top: 20px;
+}
+
+.amount-wrapper {
+    display: flex;
+}
+
+.check-wrapper {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 14px;
+    width: 14px;
+    border: none;
+    border-radius: 100%;
+    background-color: var(--neutral-text-default);
+    margin-inline: 5px;
+}
+
+.check-wrapper img {
+    filter: invert(1);
+}
+
+.amount-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}

--- a/components/dailyList/index.css
+++ b/components/dailyList/index.css
@@ -81,3 +81,15 @@
     justify-content: center;
     align-items: center;
 }
+
+.text-red {
+    color: var(--brand-text-expense);
+}
+
+.text-blue {
+    color: var(--brand-text-income);
+}
+
+.amount-line {
+    margin-left: 10px;
+}

--- a/components/dailyList/index.css
+++ b/components/dailyList/index.css
@@ -54,6 +54,7 @@
     display: flex;
     justify-content: space-between;
     margin-top: 20px;
+    width: 846px;
 }
 
 .amount-wrapper {
@@ -68,8 +69,11 @@
     width: 14px;
     border: none;
     border-radius: 100%;
-    background-color: var(--neutral-text-default);
     margin-inline: 5px;
+}
+
+.amount-btn-active {
+    background-color: var(--neutral-text-default);
 }
 
 .check-wrapper img {

--- a/components/dailyList/index.js
+++ b/components/dailyList/index.js
@@ -13,6 +13,8 @@ export default function initalizeDailyList() {
 export function dailyViewChange(year, month) {
     const $dailyRoot = document.querySelector('#daily-placeholder');
     $dailyRoot.innerHTML = '';
+    dailyData.totalExpense = 0;
+    dailyData.totalIncome = 0;
 
     let monthTotalIncome = 0;
     let monthTotalExpense = 0;
@@ -31,30 +33,59 @@ export function dailyViewChange(year, month) {
                     monthTotalExpense += -item.amount;
                 }
             });
-            $container.appendChild(createDaliyList(list));
+            const $dailyList = createDaliyList(list);
+            if ($dailyList) $container.appendChild($dailyList);
         });
+
     $dailyRoot.innerHTML = `
         <div class="total-header">
             <div class="lt-12">전체 내역    ${totalCount}건 </div>
             <div class="amount-wrapper">
                 <div class="amount-container">    
-                    <div class="check-wrapper"> 
+                    <button id="filter-income" class="check-wrapper amount-btn-active"> 
                         <img width="12" height="12" src="/public/check.svg" /> 
-                    </div>
+                    </button>
                     <span class="lt-12">수입: ${formatAmount(
-                        monthTotalIncome,
+                        dailyData.totalIncome,
                     )}</span>
                 </div>
                 <div class="amount-container">
-                    <div class="check-wrapper"> 
+                    <button id="filter-expense" class="check-wrapper amount-btn-active"> 
                         <img width="12" height="12" src="/public/check.svg" /> 
-                    </div>
+                    </button>
                     <span class="lt-12">지출: ${formatAmount(
-                        monthTotalExpense,
+                        dailyData.totalExpense,
                     )}<span>
                 </div>
             </div>
         </div>`;
     document.querySelector('#daily-placeholder').appendChild($container);
-    $dailyRoot.appendChild($container);
+
+    $dailyRoot.querySelector('#filter-income').addEventListener('click', () => {
+        dailyData.toggleIncomeFilter();
+        dailyViewChange(dateData.year, dateData.month);
+
+        const $income = document.getElementById('filter-income');
+        const $expense = document.getElementById('filter-expense');
+
+        if (dailyData.filteredIncome)
+            $income.classList.remove('amount-btn-active');
+        if (dailyData.filteredExpense)
+            $expense.classList.remove('amount-btn-active');
+    });
+    $dailyRoot
+        .querySelector('#filter-expense')
+        .addEventListener('click', () => {
+            dailyData.toggleExpenseFilter();
+            dailyViewChange(dateData.year, dateData.month);
+
+            const $income = document.getElementById('filter-income');
+            const $expense = document.getElementById('filter-expense');
+
+            console.log($expense);
+            if (dailyData.filteredExpense)
+                $expense.classList.remove('amount-btn-active');
+            if (dailyData.filteredIncome)
+                $income.classList.remove('amount-btn-active');
+        });
 }

--- a/components/dailyList/index.js
+++ b/components/dailyList/index.js
@@ -4,27 +4,53 @@ import createDaliyList from './dailyList.js';
 import dateData from '../../store/date.js';
 
 export default function initalizeDailyList() {
-    const $container = createElement('ol', { class: 'daily-list-wrapper' }, '');
     const today = new Date().toISOString().split('T')[0];
     const [year, month] = today.split('-');
 
-    dailyData
-        .getDailyByYearAndMonth(Number(year), Number(month))
-        .forEach((item) => {
-            $container.appendChild(createDaliyList(item));
-        });
-
-    document.querySelector('#daily-placeholder').appendChild($container);
+    dailyViewChange(year, month);
 }
 
-export function dailyViewChange() {
-    const { month, year } = dateData;
+export function dailyViewChange(year, month) {
     const $dailyRoot = document.querySelector('#daily-placeholder');
     $dailyRoot.innerHTML = '';
 
+    let monthTotalIncome = 0;
+    let monthTotalExpense = 0;
+    let totalCount = 0;
+
     const $container = createElement('ol', { class: 'daily-list-wrapper' }, '');
-    dailyData.getDailyByYearAndMonth(year, month).forEach((item) => {
-        $container.appendChild(createDaliyList(item));
-    });
+
+    dailyData
+        .getDailyByYearAndMonth(Number(year), Number(month))
+        .forEach((list) => {
+            list.items.forEach((item) => {
+                totalCount += 1;
+                if (item.amount > 0) {
+                    monthTotalIncome += item.amount;
+                } else {
+                    monthTotalExpense += -item.amount;
+                }
+            });
+            $container.appendChild(createDaliyList(list));
+        });
+    $dailyRoot.innerHTML = `
+        <div class="total-header">
+            <div class="lt-12">전체 내역    ${totalCount}건 </div>
+            <div class="amount-wrapper">
+                <div class="amount-container">    
+                    <div class="check-wrapper"> 
+                        <img width="12" height="12" src="/public/check.svg" /> 
+                    </div>
+                    <span class="lt-12">수입: ${monthTotalIncome}</span>
+                </div>
+                <div class="amount-container">
+                    <div class="check-wrapper"> 
+                        <img width="12" height="12" src="/public/check.svg" /> 
+                    </div>
+                    <span class="lt-12">지출: ${monthTotalExpense}<span>
+                </div>
+            </div>
+        </div>`;
+    document.querySelector('#daily-placeholder').appendChild($container);
     $dailyRoot.appendChild($container);
 }

--- a/components/dailyList/index.js
+++ b/components/dailyList/index.js
@@ -1,13 +1,30 @@
 import { createElement } from '../../utils.js';
 import { dailyData } from '../../store/daily.js';
 import createDaliyList from './dailyList.js';
+import dateData from '../../store/date.js';
 
 export default function initalizeDailyList() {
     const $container = createElement('ol', { class: 'daily-list-wrapper' }, '');
+    const today = new Date().toISOString().split('T')[0];
+    const [year, month] = today.split('-');
 
-    dailyData.data.forEach((item) => {
-        $container.appendChild(createDaliyList(item));
-    });
+    dailyData
+        .getDailyByYearAndMonth(Number(year), Number(month))
+        .forEach((item) => {
+            $container.appendChild(createDaliyList(item));
+        });
 
     document.querySelector('#daily-placeholder').appendChild($container);
+}
+
+export function dailyViewChange() {
+    const { month, year } = dateData;
+    const $dailyRoot = document.querySelector('#daily-placeholder');
+    $dailyRoot.innerHTML = '';
+
+    const $container = createElement('ol', { class: 'daily-list-wrapper' }, '');
+    dailyData.getDailyByYearAndMonth(year, month).forEach((item) => {
+        $container.appendChild(createDaliyList(item));
+    });
+    $dailyRoot.appendChild($container);
 }

--- a/components/dailyList/index.js
+++ b/components/dailyList/index.js
@@ -1,4 +1,4 @@
-import { createElement } from '../../utils.js';
+import { createElement, formatAmount } from '../../utils.js';
 import { dailyData } from '../../store/daily.js';
 import createDaliyList from './dailyList.js';
 import dateData from '../../store/date.js';
@@ -41,13 +41,17 @@ export function dailyViewChange(year, month) {
                     <div class="check-wrapper"> 
                         <img width="12" height="12" src="/public/check.svg" /> 
                     </div>
-                    <span class="lt-12">수입: ${monthTotalIncome}</span>
+                    <span class="lt-12">수입: ${formatAmount(
+                        monthTotalIncome,
+                    )}</span>
                 </div>
                 <div class="amount-container">
                     <div class="check-wrapper"> 
                         <img width="12" height="12" src="/public/check.svg" /> 
                     </div>
-                    <span class="lt-12">지출: ${monthTotalExpense}<span>
+                    <span class="lt-12">지출: ${formatAmount(
+                        monthTotalExpense,
+                    )}<span>
                 </div>
             </div>
         </div>`;

--- a/components/header/centerNavigation.js
+++ b/components/header/centerNavigation.js
@@ -35,11 +35,11 @@ export default function createCenterNavigation() {
 
     $minusBtn.addEventListener('click', () => {
         dateData.decreaseMonth();
-        dailyViewChange();
+        dailyViewChange(dateData.year, dateData.month);
     });
     $plusBtn.addEventListener('click', () => {
         dateData.increaseMonth();
-        dailyViewChange();
+        dailyViewChange(dateData.year, dateData.month);
     });
 
     return $centerNavigation;

--- a/components/header/centerNavigation.js
+++ b/components/header/centerNavigation.js
@@ -1,5 +1,6 @@
 import { createElement } from '../../utils.js';
 import dateData from '../../store/date.js';
+import { dailyViewChange } from '../dailyList/index.js';
 
 export default function createCenterNavigation() {
     const centerNavigationHTML = `
@@ -34,9 +35,11 @@ export default function createCenterNavigation() {
 
     $minusBtn.addEventListener('click', () => {
         dateData.decreaseMonth();
+        dailyViewChange();
     });
     $plusBtn.addEventListener('click', () => {
         dateData.increaseMonth();
+        dailyViewChange();
     });
 
     return $centerNavigation;

--- a/components/inputbar/inputItems/amount.js
+++ b/components/inputbar/inputItems/amount.js
@@ -7,8 +7,9 @@ export default function createAmountInput() {
                 금액
             </label>
             <div class="value-box">
-                <button>
+                <button id="toggle-sign">
                     <img
+                        id="sign"
                         src="/public/minus.svg"
                         aria-label="마이너스 바 "
                         width="16px"
@@ -37,5 +38,16 @@ export default function createAmountInput() {
         formData.setAmount(inputValue);
     });
 
+    const $toggleBtn = $valueInputItem.querySelector('#toggle-sign');
+    $toggleBtn.addEventListener('click', (e) => {
+        const nowSrc = e.target.getAttribute('src');
+        if (nowSrc.includes('minus')) {
+            e.target.setAttribute('src', '/public/plus.svg');
+        } else {
+            e.target.setAttribute('src', '/public/minus.svg');
+        }
+
+        formData.setSign(!formData.sign);
+    });
     return $valueInputItem;
 }

--- a/components/inputbar/summitBtn.js
+++ b/components/inputbar/summitBtn.js
@@ -1,6 +1,8 @@
 import { createElement } from '../../utils.js';
 import formData from '../../store/formData.js';
 import { dailyData } from '../../store/daily.js';
+import dateData from '../../store/date.js';
+import { dailyViewChange } from '../dailyList/index.js';
 
 export default function createSummitButton() {
     const summitBtnInnerHtml = `
@@ -25,6 +27,11 @@ export default function createSummitButton() {
     $btn.addEventListener('click', () => {
         if (!formData.isValid) return;
         dailyData.uploadDailyData(formData);
+        const { year: nowYear, month: nowMonth } = dateData;
+        const [year, month] = formData.date.split('-');
+
+        if (nowYear == year && month == nowMonth)
+            dailyViewChange(nowYear, nowMonth);
     });
 
     formData.subscribeIsValid((isValid) => {

--- a/store/daily.js
+++ b/store/daily.js
@@ -1,7 +1,3 @@
-import createDaily from '../components/dailyList/daily.js';
-import createDaliyList from '../components/dailyList/dailyList.js';
-import { formatDateToKorean } from '../utils.js';
-
 export const dailyData = {
     data: [],
     async init() {
@@ -39,37 +35,3 @@ export const dailyData = {
         });
     },
 };
-
-dailyData.init();
-
-function updateDailyView(data) {
-    const $dailyContainer = document.querySelector('.daily-list-wrapper'); // 여긴 ID 맞게 수정
-
-    const { date } = data;
-    const dateToKorean = formatDateToKorean(date);
-
-    let $dateSection = [...$dailyContainer.children].find(
-        (section) =>
-            section.querySelector('.date-info')?.textContent === dateToKorean,
-    );
-
-    if ($dateSection) {
-        const $newItem = createDaily(data);
-        const $list = $dateSection.querySelector('.daliy-line-wrapper');
-        $list.appendChild($newItem);
-    } else {
-        const listData = {
-            date: data.date,
-            items: [
-                {
-                    amount: data.amount,
-                    category: data.category,
-                    description: data.description,
-                    payment: data.payment,
-                },
-            ],
-        };
-        const $newItemList = createDaliyList(listData);
-        $dailyContainer.appendChild($newItemList);
-    }
-}

--- a/store/daily.js
+++ b/store/daily.js
@@ -12,12 +12,14 @@ export const dailyData = {
     },
 
     uploadDailyData(data) {
-        const { amount, category, date, description, payment } = data;
+        const { amount, category, date, description, payment, sign } = data;
+        let numberAmount = Number(amount.replace(/,/g, ''));
+        if (!sign) numberAmount *= -1;
         const newItems = {
             category,
             description,
             payment,
-            amount: Number(amount.replace(/,/g, '')),
+            amount: numberAmount,
             createAt: new Date().toISOString(),
         };
 

--- a/store/daily.js
+++ b/store/daily.js
@@ -1,5 +1,9 @@
 export const dailyData = {
     data: [],
+    filteredIncome: false,
+    filteredExpense: false,
+    totalIncome: 0,
+    totalExpense: 0,
     async init() {
         await this.fetch();
     },
@@ -44,5 +48,13 @@ export const dailyData = {
             const date = new Date(item.date);
             return date.getMonth() + 1 === month && date.getFullYear() === year;
         });
+    },
+
+    toggleIncomeFilter() {
+        this.filteredIncome = !this.filteredIncome;
+    },
+
+    toggleExpenseFilter() {
+        this.filteredExpense = !this.filteredExpense;
     },
 };

--- a/store/daily.js
+++ b/store/daily.js
@@ -34,11 +34,8 @@ export const dailyData = {
     },
 
     getDailyByYearAndMonth(year, month) {
-        console.log(year, month);
-        console.log(this.data);
         return this.data.filter((item) => {
             const date = new Date(item.date);
-            console.log(date.getMonth(), date.getFullYear());
             return date.getMonth() + 1 === month && date.getFullYear() === year;
         });
     },

--- a/store/daily.js
+++ b/store/daily.js
@@ -30,7 +30,6 @@ export const dailyData = {
         } else {
             this.data = [{ date: date, items: [newItems] }, ...this.data];
         }
-        updateDailyView(data);
     },
 
     getDailyByYearAndMonth(year, month) {

--- a/store/daily.js
+++ b/store/daily.js
@@ -13,7 +13,6 @@ export const dailyData = {
 
     uploadDailyData(data) {
         const { amount, category, date, description, payment } = data;
-        const targetDateObj = this.data.find((item) => item.date === date);
         const newItems = {
             category,
             description,
@@ -21,10 +20,20 @@ export const dailyData = {
             amount: Number(amount.replace(/,/g, '')),
             createAt: new Date().toISOString(),
         };
+
+        const targetDateObj = this.data.find((item) => item.date === date);
         if (targetDateObj) {
             targetDateObj.items.push(newItems);
         } else {
-            this.data = [{ date: date, items: [newItems] }, ...this.data];
+            const newGroup = { date, items: [newItems] };
+            const index = this.data.findIndex(
+                (item) => new Date(date) < new Date(item.date),
+            );
+            if (index === -1) {
+                this.data.push(newGroup);
+            } else {
+                this.data.splice(index, 0, newGroup);
+            }
         }
     },
 

--- a/store/daily.js
+++ b/store/daily.js
@@ -32,6 +32,16 @@ export const dailyData = {
         }
         updateDailyView(data);
     },
+
+    getDailyByYearAndMonth(year, month) {
+        console.log(year, month);
+        console.log(this.data);
+        return this.data.filter((item) => {
+            const date = new Date(item.date);
+            console.log(date.getMonth(), date.getFullYear());
+            return date.getMonth() + 1 === month && date.getFullYear() === year;
+        });
+    },
 };
 
 dailyData.init();

--- a/store/formData.js
+++ b/store/formData.js
@@ -11,7 +11,6 @@ const formData = {
     isValidListeners: new Set(),
 
     setSign(value) {
-        console.log(value);
         this.sign = value;
     },
 

--- a/store/formData.js
+++ b/store/formData.js
@@ -5,9 +5,15 @@ const formData = {
     payment: null,
     category: null,
     createDate: null,
+    sign: false,
     isValid: false,
 
     isValidListeners: new Set(),
+
+    setSign(value) {
+        console.log(value);
+        this.sign = value;
+    },
 
     setDate(dateValue) {
         this.date = dateValue;

--- a/utils.js
+++ b/utils.js
@@ -29,3 +29,8 @@ export function formatDateToKorean(dateStr) {
 
     return `${month}월 ${day}일 ${weekday}`;
 }
+
+export function formatAmount(value) {
+    const textValue = String(value);
+    return textValue.replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+}


### PR DESCRIPTION


https://github.com/user-attachments/assets/53834c25-e66f-4831-af7e-dab07b9830d6




## 완료 작업 목록
- 월별 데이터를 가져와 렌더링
dailyViewchange함수를 이용한 전체 리렌더링 방식으로 전환
데이터 추가 시 조건에 맞도록 정렬
현재 보고 있는 연도와 달에 추가하면 바로 리렌더링
- amount 형식에 맞게 바꿔주는 유틸 함수 생성
- input amount 옆에 토글 버튼에 따른 부호 적용
- 수입과 지출 버튼에 따른 필터링 적용

## 주요 고민과 해결 과정
- 기존에 데일리 컴포넌트를 이미 렌더링된 돔에다가 추가하는 방식으로 리스트를 형성해보려고 하였으나 그 과정이 너무 복잡하고 많이 꼬여있다는 것을 느꼈습니다. 하나의 뷰 컴포넌트를 가지고 데이터가 변경되었을 때 모두 리렌더링되는 방식을 고민하였는데 성능에 문제가 있지 않을까 검색을 해보니 전체를 리렌더링하는 방식을 많이 사용하고 또 생각보다 많은 수가 있지 않은 이상 렌더링에도 무리가 없다는 점을 알게되었고 이러한 방식으로 개발하는 것이 추후 복잡하지 않아 유지보수 또한 간단하다는 것을 알게되었고 이런식으로 개발하다가 너무 많아진다 싶으면 diffing 알고리즘같은 것을 공부하여 구현하는 것도 좋아보인다.

- 필터링을 구현하면서 필터의 상태와 어떠한 컴포넌트에서 필요하고 필요하지 않은 daily-line를 구분할지 고민을 많이 했다. 결국 store에 있는 dailyData에서 필터들의 상태를 관리하는 식으로 만들었고 이를 만드는데에 급급하여 이 기능을 구현할때는 보기 쉽고 기능에 따라 나눠진 코드보다는 동작하는 기능을 만드는데 집중했었던거같다. 데일리 컨테이너의 헤더까지 리렌더링을 하는 방식이 아닌 필터버튼이 있는 헤더는 유지하고 textContent로 지출 수입을 바꾸면서 아래 내용만 바꾸는 것이 좋은 생각이였을지도 모르겠다.