### PR TITLE
[조은진] - 수정 기능, 캘린더 구현

### DIFF
--- a/components/calendar.js
+++ b/components/calendar.js
@@ -106,7 +106,7 @@ export function createCalendar(year, month) {
 
   const calendarHeader = `
     <div class="calendar-header light-12">
-        ${WEEKDAYS.map((day) => `<div>${day}</div>`).join("")}
+        ${WEEKDAYS.reduce((acc, day) => acc + `<div>${day}</div>`, "")}
     </div>
     `;
 

--- a/components/calendar.js
+++ b/components/calendar.js
@@ -3,7 +3,9 @@ import {
   getTransactionsByYearMonth,
   groupTransactionsByDate,
   dailyTotalData,
+  monthlyTotalData,
 } from "../utils/transaction.js";
+import { formatMoney } from "../utils/format.js";
 
 const WEEKDAYS = ["일", "월", "화", "수", "목", "금", "토"];
 
@@ -28,17 +30,21 @@ function createCalendarCell(day, year, month, transactionListByDate) {
 
   const createCalendarTotalIncomeAmount =
     dailyTotalIncomeCount > 0
-      ? `<div class="calendar-amount text-income">${dailyTotalIncome}</div>`
+      ? `<div class="calendar-amount text-income">${formatMoney(
+          dailyTotalIncome
+        )}</div>`
       : ``;
 
   const createCalendarTotalExpenseAmount =
     dailyTotalExpenseCount > 0
-      ? `<div class="calendar-amount text-expense">${dailyTotalExpense}</div>`
+      ? `<div class="calendar-amount text-expense">${formatMoney(
+          dailyTotalExpense
+        )}</div>`
       : ``;
 
   const createCalendarTotalAmount =
     dailyTotalCount > 0
-      ? `<div class="calendar-amount">${dailyTotalAmount}</div>`
+      ? `<div class="calendar-amount">${formatMoney(dailyTotalAmount)}</div>`
       : ``;
 
   return `
@@ -51,6 +57,21 @@ function createCalendarCell(day, year, month, transactionListByDate) {
         <div class="calendar-date serif-14">${day}</div>
       </div>
     `;
+}
+
+function createCalendarMonthlyInfo(year, month) {
+  const transactions = getTransactionsByYearMonth(year, month);
+  const { monthlyTotalIncome, monthlyTotalExpense } =
+    monthlyTotalData(transactions);
+  return `
+  <div class="calendar-info flex-between serif-14">
+      <div class="flex-row gap-8">
+          <div>총 수입 ${formatMoney(monthlyTotalIncome)}원</div>
+          <div>총 지출${formatMoney(monthlyTotalExpense)}원</div>
+      </div>
+      <div>총 ${formatMoney(monthlyTotalIncome + monthlyTotalExpense)} 원</div>
+  </div>
+  `;
 }
 
 export function createCalendar(year, month) {
@@ -111,4 +132,11 @@ export function createCalendar(year, month) {
 
 export function renderCalendar(container) {
   container.innerHTML = createCalendar(getCurrentYear(), getCurrentMonth());
+}
+
+export function renderCalendarInfo(container) {
+  container.innerHTML = createCalendarMonthlyInfo(
+    getCurrentYear(),
+    getCurrentMonth()
+  );
 }

--- a/components/calendar.js
+++ b/components/calendar.js
@@ -2,6 +2,7 @@ import { getCurrentYear, getCurrentMonth } from "../utils/currentDate.js";
 import {
   getTransactionsByYearMonth,
   groupTransactionsByDate,
+  dailyTotalData,
 } from "../utils/transaction.js";
 
 const WEEKDAYS = ["일", "월", "화", "수", "목", "금", "토"];
@@ -16,29 +17,35 @@ function createCalendarCell(day, year, month, transactionListByDate) {
 
   const transactions = transactionListByDate[key] || [];
 
-  const totalAmount = transactions.reduce((sum, t) => sum + t.amount, 0);
+  const {
+    dailyTotalIncome,
+    dailyTotalExpense,
+    dailyTotalIncomeCount,
+    dailyTotalExpenseCount,
+    dailyTotalAmount,
+    dailyTotalCount,
+  } = dailyTotalData(transactions);
 
-  const createCalendarAmount =
-    transactions.length > 0
-      ? transactions
-          .map(
-            (transaction) =>
-              `<div class="calendar-amount ${
-                transaction.amount > 0 ? "text-income" : "text-expense"
-              }">${transaction.amount ?? ""}</div>`
-          )
-          .join("")
+  const createCalendarTotalIncomeAmount =
+    dailyTotalIncomeCount > 0
+      ? `<div class="calendar-amount text-income">${dailyTotalIncome}</div>`
+      : ``;
+
+  const createCalendarTotalExpenseAmount =
+    dailyTotalExpenseCount > 0
+      ? `<div class="calendar-amount text-expense">${dailyTotalExpense}</div>`
       : ``;
 
   const createCalendarTotalAmount =
-    transactions.length > 0
-      ? `<div class="calendar-amount">${totalAmount}</div>`
+    dailyTotalCount > 0
+      ? `<div class="calendar-amount">${dailyTotalAmount}</div>`
       : ``;
 
   return `
       <div class="calendar-cell" data-date="${day}">
         <div class="calendar-cell-details light-14">
-            ${createCalendarAmount}
+            ${createCalendarTotalIncomeAmount}
+            ${createCalendarTotalExpenseAmount}
             ${createCalendarTotalAmount}
         </div>
         <div class="calendar-date serif-14">${day}</div>

--- a/components/calendar.js
+++ b/components/calendar.js
@@ -1,0 +1,107 @@
+import { getCurrentYear, getCurrentMonth } from "../utils/currentDate.js";
+import {
+  getTransactionsByYearMonth,
+  groupTransactionsByDate,
+} from "../utils/transaction.js";
+
+const WEEKDAYS = ["일", "월", "화", "수", "목", "금", "토"];
+
+function createCalendarCell(day, year, month, transactionListByDate) {
+  if (!day) return `<div class="calendar-cell empty"></div>`;
+
+  const key = `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(
+    2,
+    "0"
+  )}`;
+
+  const transactions = transactionListByDate[key] || [];
+
+  const totalAmount = transactions.reduce((sum, t) => sum + t.amount, 0);
+
+  const createCalendarAmount =
+    transactions.length > 0
+      ? transactions
+          .map(
+            (transaction) =>
+              `<div class="calendar-amount ${
+                transaction.amount > 0 ? "text-income" : "text-expense"
+              }">${transaction.amount ?? ""}</div>`
+          )
+          .join("")
+      : ``;
+
+  const createCalendarTotalAmount =
+    transactions.length > 0
+      ? `<div class="calendar-amount">${totalAmount}</div>`
+      : ``;
+
+  return `
+      <div class="calendar-cell" data-date="${day}">
+        <div class="calendar-cell-details light-14">
+            ${createCalendarAmount}
+            ${createCalendarTotalAmount}
+        </div>
+        <div class="calendar-date serif-14">${day}</div>
+      </div>
+    `;
+}
+
+export function createCalendar(year, month) {
+  const transactions = getTransactionsByYearMonth(year, month);
+  const transactionListByDate = groupTransactionsByDate(transactions);
+
+  // month: 1~12
+  const firstDay = new Date(year, month - 1, 1);
+  const lastDay = new Date(year, month, 0);
+
+  const firstDayOfWeek = firstDay.getDay(); //첫째 날이 시작되는 요일 인덱스
+  const daysInMonth = lastDay.getDate(); // 이번 달의 마지막 날의 날짜
+
+  const days = [
+    ...Array(firstDayOfWeek).fill(null),
+    ...Array.from({ length: daysInMonth }, (_, i) => i + 1),
+  ];
+
+  // 날짜가 7로 나누어 떨어지지 않으면 나머지 날짜를 추가
+  const remainder = days.length % 7;
+  if (remainder !== 0) {
+    days.push(...Array(7 - remainder).fill(null));
+  }
+
+  // 2차원 배열 생성
+  const weeks = days.reduce((acc, _, i) => {
+    if (i % 7 === 0) {
+      acc.push(days.slice(i, i + 7));
+    }
+    return acc;
+  }, []);
+
+  const calendarHeader = `
+    <div class="calendar-header light-12">
+        ${WEEKDAYS.map((day) => `<div>${day}</div>`).join("")}
+    </div>
+    `;
+
+  const calendarBody = `
+    <div class="calendar-body">
+      ${weeks
+        .map(
+          (week) =>
+            `<div class="calendar-row">
+              ${week
+                .map((day) =>
+                  createCalendarCell(day, year, month, transactionListByDate)
+                )
+                .join("")}
+            </div>`
+        )
+        .join("")}
+    </div>
+  `;
+
+  return calendarHeader + calendarBody;
+}
+
+export function renderCalendar(container) {
+  container.innerHTML = createCalendar(getCurrentYear(), getCurrentMonth());
+}

--- a/components/inputBar.js
+++ b/components/inputBar.js
@@ -1,8 +1,13 @@
-import { addNewTransaction, updateTransaction } from "../utils/transaction.js";
+import {
+  addNewTransaction,
+  updateTransaction,
+  monthlyTotalData,
+  getTransactionsByYearMonth,
+} from "../utils/transaction.js";
 import { getCurrentYear, getCurrentMonth } from "../utils/currentDate.js";
 import { renderTransactionList } from "./transactionsList.js";
 import { getFilteringState } from "../pages.js";
-import { renderMonthlyInfo } from "./monthlyInfo.js";
+import { renderMonthlyInfo, renderTotalCount } from "./monthlyInfo.js";
 
 // 수정 모드 상태 관리
 let isEditMode = false;
@@ -290,10 +295,17 @@ export function renderInputBar(container) {
 
     // 거래내역 목록 업데이트
     const { isIncomeChecked, isExpenseChecked } = getFilteringState();
-    renderMonthlyInfo(
-      document.querySelector("#monthly-info-container"),
+    const monthlyInfoContainer = document.querySelector(
+      "#monthly-info-container"
+    );
+    renderMonthlyInfo(monthlyInfoContainer, isIncomeChecked, isExpenseChecked);
+    renderTotalCount(
+      monthlyInfoContainer,
       isIncomeChecked,
-      isExpenseChecked
+      isExpenseChecked,
+      monthlyTotalData(
+        getTransactionsByYearMonth(getCurrentYear(), getCurrentMonth())
+      )
     );
     renderTransactionList(isIncomeChecked, isExpenseChecked);
   });

--- a/components/inputBar.js
+++ b/components/inputBar.js
@@ -1,17 +1,18 @@
+import { getCurrentYear, getCurrentMonth } from "../utils/currentDate.js";
 import {
+  getTransactionsByYearMonth,
   addNewTransaction,
   updateTransaction,
   monthlyTotalData,
-  getTransactionsByYearMonth,
 } from "../utils/transaction.js";
-import { getCurrentYear, getCurrentMonth } from "../utils/currentDate.js";
-import { renderTransactionList } from "./transactionsList.js";
 import { getFilteringState } from "../pages.js";
-import { renderMonthlyInfo, renderTotalCount } from "./monthlyInfo.js";
 import {
   INCOME_CATEGORIES,
   EXPENSE_CATEGORIES,
 } from "../constants/category.js";
+import { renderMonthlyInfo, renderTotalCount } from "./monthlyInfo.js";
+import { renderTransactionList } from "./transactionsList.js";
+import { renderCalendar, renderCalendarInfo } from "./calendar.js";
 
 // 수정 모드 상태 관리
 let isEditMode = false;
@@ -36,56 +37,30 @@ function createCategoryOptions(isIncome) {
 }
 
 export function createInputBar() {
-  return ` 
-  <form
-    class="input-bar flex-row"
-    id="inputBarForm"
-  >
+  const today = new Date().toISOString().split("T")[0];
+  return `
+  <form class="input-bar flex-row" id="inputBarForm">
     <label class="flex-column input-section">
       <div class="input-label light-12">일자</div>
-      <input type="date" name="date" class="date-input semibold-12" required value="${
-        new Date().toISOString().split("T")[0]
-      }" />
+      <input type="date" name="date" class="date-input semibold-12" required value="${today}" />
     </label>
     <label class="flex-column input-section">
       <div class="input-label light-12">금액</div>
       <div class="flex-row semibold-12">
-        <button
-          type="button"
-          class="amount-toggle"
-          data-sign="+"
-        >
+        <button type="button" class="amount-toggle" data-sign="+">
           <img src="../icons/plus.svg" alt="plus" />
         </button>
-        <input
-          type="number"
-          name="amount"
-          placeholder="0"
-          min="0"
-          required
-          class="semibold-12 text-input"
-        />
+        <input type="number" name="amount" placeholder="0" min="0" required class="semibold-12 text-input" />
         <div class="semibold-12">원</div>
       </div>
     </label>
     <label class="flex-column input-section">
       <div class="input-label light-12">내용</div>
-      <input
-        type="text"
-        name="content"
-        maxlength="32"
-        placeholder="내용을 입력하세요"
-        required
-        class="semibold-12 text-input"
-      />
+      <input type="text" name="content" maxlength="32" placeholder="내용을 입력하세요" required class="semibold-12 text-input" />
     </label>
     <label class="flex-column input-section">
       <div class="input-label light-12">결제수단</div>
-      <select
-        name="paymentMethod"
-        required
-        class="semibold-12 text-input"
-      >
+      <select name="paymentMethod" required class="semibold-12 text-input">
         <option value="" disabled selected hidden>선택하세요</option>
         <option value="현금">현금</option>
         <option value="카드">카드</option>
@@ -94,11 +69,7 @@ export function createInputBar() {
     </label>
     <label class="flex-column w-full px-20">
       <div class="input-label light-12">분류</div>
-      <select
-        name="category"
-        required
-        class="semibold-12 text-input"
-      >
+      <select name="category" required class="semibold-12 text-input">
         <option value="" disabled selected hidden>선택하세요</option>
         <option value="생활">생활</option>
         <option value="식비">식비</option>
@@ -110,11 +81,7 @@ export function createInputBar() {
       </select>
     </label>
     <div class="flex-column">
-      <button
-        type="submit"
-        class="add-button"
-        id="submitButton"
-      >
+      <button type="submit" class="add-button" id="submitButton">
         <img src="../icons/check.svg" alt="check" />
       </button>
     </div>
@@ -122,7 +89,6 @@ export function createInputBar() {
   `;
 }
 
-// 폼 요소들을 가져오는 함수
 function getFormElements(form) {
   return {
     dateInput: form.querySelector(`input[name='${FORM_FIELDS.DATE}']`),
@@ -139,116 +105,88 @@ function getFormElements(form) {
   };
 }
 
-// 금액 토글 아이콘 변경 함수
-function updateAmountToggleIcon(amountToggle, isPositive) {
-  const icon = isPositive ? "plus.svg" : "minus.svg";
-  const sign = isPositive ? "+" : "-";
-  amountToggle.querySelector("img").src = `../icons/${icon}`;
-  amountToggle.querySelector("img").alt = sign;
-  amountToggle.dataset.sign = sign;
+function getRequiredFields(elements) {
+  return {
+    dateInput: elements.dateInput,
+    amountInput: elements.amountInput,
+    contentInput: elements.contentInput,
+    paymentMethodSelect: elements.paymentMethodSelect,
+    categorySelect: elements.categorySelect,
+  };
 }
 
-// 폼 초기화 함수
+function validateForm(fields, submitButton) {
+  const isValid = Object.values(fields).every((field) => {
+    if (field.tagName === "SELECT") return field.value !== "";
+    return field.value.trim() !== "";
+  });
+  submitButton.disabled = !isValid;
+  submitButton.classList.toggle("disabled", !isValid);
+}
+
+function updateAmountToggleIcon(toggle, isPositive) {
+  const icon = isPositive ? "plus.svg" : "minus.svg";
+  const sign = isPositive ? "+" : "-";
+  toggle.querySelector("img").src = `../icons/${icon}`;
+  toggle.querySelector("img").alt = sign;
+  toggle.dataset.sign = sign;
+}
+
 function resetForm(form, elements) {
   form.reset();
   updateAmountToggleIcon(elements.amountToggle, true);
   validateForm(getRequiredFields(elements), elements.submitButton);
 }
 
-// 필수 필드 배열 생성 함수
-function getRequiredFields(elements) {
-  return [
-    elements.dateInput,
-    elements.amountInput,
-    elements.contentInput,
-    elements.paymentMethodSelect,
-    elements.categorySelect,
-  ];
-}
-
-// 폼 데이터 처리 함수
 function processFormData(formData, amountToggle) {
   const data = Object.fromEntries(formData.entries());
-
-  // amountToggle 상태에 따라 금액 부호 결정
-  if (amountToggle && amountToggle.dataset.sign === "-") {
-    data.amount = -Math.abs(parseInt(data.amount));
-  } else {
-    data.amount = Math.abs(parseInt(data.amount));
-  }
-
+  data.amount =
+    amountToggle.dataset.sign === "-"
+      ? -Math.abs(+data.amount)
+      : Math.abs(+data.amount);
   return data;
 }
 
-// 폼을 거래내역 데이터로 채우는 함수
 export function fillFormWithTransaction(transaction) {
   const form = document.getElementById("inputBarForm");
   if (!form || !transaction) return;
 
-  const {
-    dateInput,
-    amountInput,
-    contentInput,
-    paymentMethodSelect,
-    categorySelect,
-    amountToggle,
-    submitButton,
-  } = getFormElements(form);
+  const elements = getFormElements(form);
+  const fields = getRequiredFields(elements);
 
-  // 폼 필드에 데이터 설정
-  dateInput.value = transaction.date;
-  amountInput.value = Math.abs(transaction.amount);
-  contentInput.value = transaction.description;
-  paymentMethodSelect.value = transaction.paymentMethod;
-  categorySelect.value = transaction.category;
+  elements.dateInput.value = transaction.date;
+  elements.amountInput.value = Math.abs(transaction.amount);
 
-  // 금액 토글 설정
-  updateAmountToggleIcon(amountToggle, transaction.amount > 0);
+  updateAmountToggleIcon(elements.amountToggle, transaction.amount > 0);
+  updateCategoryOptions(elements, transaction.amount > 0);
+  elements.contentInput.value = transaction.description;
+  elements.paymentMethodSelect.value = transaction.paymentMethod;
+  elements.categorySelect.value = transaction.category;
 
-  // 수정 모드로 설정
   isEditMode = true;
   editingTransactionId = transaction.id;
 
-  // 유효성 검사 실행
-  validateForm(
-    [dateInput, amountInput, contentInput, paymentMethodSelect, categorySelect],
-    submitButton
-  );
+  validateForm(fields, elements.submitButton);
 }
 
-// 수정 모드 초기화 함수
 export function resetEditMode() {
   isEditMode = false;
   editingTransactionId = null;
-
-  // 선택된 행 스타일 초기화
-  const selectedRows = document.querySelectorAll(".transaction-row.selected");
-  selectedRows.forEach((row) => row.classList.remove("selected"));
+  document
+    .querySelectorAll(".transaction-row.selected")
+    .forEach((row) => row.classList.remove("selected"));
 }
 
-// 수정 모드 해제 함수 (폼 초기화 포함)
 export function cancelEditMode() {
   const form = document.getElementById("inputBarForm");
-  if (form) {
-    const elements = getFormElements(form);
-
-    // 폼 초기화
-    resetForm(form, elements);
-
-    // 수정 모드 상태 초기화
-    resetEditMode();
-  }
+  if (!form) return;
+  const elements = getFormElements(form);
+  resetForm(form, elements);
+  resetEditMode();
 }
 
-function validateForm(requiredFields, submitButton) {
-  const isValid = requiredFields.every((field) => {
-    if (field.tagName === "SELECT") {
-      return field.value !== "";
-    }
-    return field.value.trim() !== "";
-  });
-  submitButton.disabled = !isValid;
-  submitButton.classList.toggle("disabled", !isValid);
+function updateCategoryOptions(elements, isIncome) {
+  elements.categorySelect.innerHTML = createCategoryOptions(isIncome);
 }
 
 export function renderInputBar(container) {
@@ -256,50 +194,32 @@ export function renderInputBar(container) {
 
   const form = container.querySelector("#inputBarForm");
   const elements = getFormElements(form);
-  const requiredFields = getRequiredFields(elements);
+  const fields = getRequiredFields(elements);
 
-  // 카테고리 select 요소 가져오기
-  const categorySelect = elements.categorySelect;
-
-  // 카테고리 옵션을 동적으로 변경하는 함수
-  function updateCategoryOptions(isIncome) {
-    categorySelect.innerHTML = createCategoryOptions(isIncome);
-  }
-
-  // 모든 필드에 이벤트 리스너 추가
-  requiredFields.forEach((field) => {
-    const eventType = field.tagName === "SELECT" ? "change" : "input";
-    field.addEventListener(eventType, () =>
-      validateForm(requiredFields, elements.submitButton)
+  Object.values(fields).forEach((field) => {
+    const type = field.tagName === "SELECT" ? "change" : "input";
+    field.addEventListener(type, () =>
+      validateForm(fields, elements.submitButton)
     );
   });
 
-  // 초기 상태 검사
-  validateForm(requiredFields, elements.submitButton);
+  validateForm(fields, elements.submitButton);
 
-  // 금액 토글 이벤트 리스너
   if (elements.amountToggle) {
     elements.amountToggle.addEventListener("click", () => {
-      const isCurrentlyPositive = elements.amountToggle.dataset.sign === "+";
-      updateAmountToggleIcon(elements.amountToggle, !isCurrentlyPositive);
-
-      // 부호에 따라 카테고리 옵션 변경
-      updateCategoryOptions(!isCurrentlyPositive);
+      const isPositive = elements.amountToggle.dataset.sign === "+";
+      updateAmountToggleIcon(elements.amountToggle, !isPositive);
+      updateCategoryOptions(elements, !isPositive);
     });
-
-    // 페이지 최초 렌더 시 카테고리 옵션도 초기화
-    updateCategoryOptions(true);
+    updateCategoryOptions(elements, true);
   }
 
-  // 폼 제출 이벤트 리스너
   form.addEventListener("submit", (e) => {
     e.preventDefault();
-
     const formData = new FormData(form);
     const data = processFormData(formData, elements.amountToggle);
 
     if (isEditMode && editingTransactionId) {
-      // 수정 모드: 기존 거래내역 수정
       updateTransaction(
         getCurrentYear(),
         getCurrentMonth(),
@@ -308,19 +228,14 @@ export function renderInputBar(container) {
       );
       resetEditMode();
     } else {
-      // 추가 모드: 새로운 거래내역 추가
       addNewTransaction(getCurrentYear(), getCurrentMonth(), data);
-      // 새로운 거래내역 추가 시 선택 상태 초기화
-      const selectedRows = document.querySelectorAll(
-        ".transaction-row.selected"
-      );
-      selectedRows.forEach((row) => row.classList.remove("selected"));
+      document
+        .querySelectorAll(".transaction-row.selected")
+        .forEach((row) => row.classList.remove("selected"));
     }
 
-    // 폼 초기화
     resetForm(form, elements);
 
-    // 거래내역 목록 업데이트
     const { isIncomeChecked, isExpenseChecked } = getFilteringState();
     const monthlyInfoContainer = document.querySelector(
       "#monthly-info-container"
@@ -337,14 +252,10 @@ export function renderInputBar(container) {
     renderTransactionList(isIncomeChecked, isExpenseChecked);
 
     const calendarContainer = document.querySelector(".calendar-container");
-    if (calendarContainer) {
-      renderCalendar(calendarContainer);
-    }
+    if (calendarContainer) renderCalendar(calendarContainer);
     const calendarInfoContainer = document.querySelector(
       ".calendar-info-container"
     );
-    if (calendarInfoContainer) {
-      renderCalendarInfo(calendarInfoContainer);
-    }
+    if (calendarInfoContainer) renderCalendarInfo(calendarInfoContainer);
   });
 }

--- a/components/inputBar.js
+++ b/components/inputBar.js
@@ -204,6 +204,20 @@ export function resetEditMode() {
   selectedRows.forEach((row) => row.classList.remove("selected"));
 }
 
+// 수정 모드 해제 함수 (폼 초기화 포함)
+export function cancelEditMode() {
+  const form = document.getElementById("inputBarForm");
+  if (form) {
+    const elements = getFormElements(form);
+
+    // 폼 초기화
+    resetForm(form, elements);
+
+    // 수정 모드 상태 초기화
+    resetEditMode();
+  }
+}
+
 function validateForm(requiredFields, submitButton) {
   const isValid = requiredFields.every((field) => {
     if (field.tagName === "SELECT") {

--- a/components/inputBar.js
+++ b/components/inputBar.js
@@ -335,5 +335,16 @@ export function renderInputBar(container) {
       )
     );
     renderTransactionList(isIncomeChecked, isExpenseChecked);
+
+    const calendarContainer = document.querySelector(".calendar-container");
+    if (calendarContainer) {
+      renderCalendar(calendarContainer);
+    }
+    const calendarInfoContainer = document.querySelector(
+      ".calendar-info-container"
+    );
+    if (calendarInfoContainer) {
+      renderCalendarInfo(calendarInfoContainer);
+    }
   });
 }

--- a/components/inputBar.js
+++ b/components/inputBar.js
@@ -1,11 +1,8 @@
-import {
-  addNewTransaction,
-  updateTransaction,
-  getTransactionById,
-} from "../utils/transaction.js";
+import { addNewTransaction, updateTransaction } from "../utils/transaction.js";
 import { getCurrentYear, getCurrentMonth } from "../utils/currentDate.js";
 import { renderTransactionList } from "./transactionsList.js";
 import { getFilteringState } from "../pages.js";
+import { renderMonthlyInfo } from "./monthlyInfo.js";
 
 // 수정 모드 상태 관리
 let isEditMode = false;
@@ -170,28 +167,35 @@ export function fillFormWithTransaction(transaction) {
   const form = document.getElementById("inputBarForm");
   if (!form || !transaction) return;
 
-  const elements = getFormElements(form);
+  const {
+    dateInput,
+    amountInput,
+    contentInput,
+    paymentMethodSelect,
+    categorySelect,
+    amountToggle,
+    submitButton,
+  } = getFormElements(form);
 
   // 폼 필드에 데이터 설정
-  elements.dateInput.value = transaction.date;
-  elements.amountInput.value = Math.abs(transaction.amount);
-  elements.contentInput.value = transaction.description;
-  elements.paymentMethodSelect.value = transaction.paymentMethod;
-  elements.categorySelect.value = transaction.category;
+  dateInput.value = transaction.date;
+  amountInput.value = Math.abs(transaction.amount);
+  contentInput.value = transaction.description;
+  paymentMethodSelect.value = transaction.paymentMethod;
+  categorySelect.value = transaction.category;
 
   // 금액 토글 설정
-  updateAmountToggleIcon(elements.amountToggle, transaction.amount > 0);
+  updateAmountToggleIcon(amountToggle, transaction.amount > 0);
 
   // 수정 모드로 설정
   isEditMode = true;
   editingTransactionId = transaction.id;
 
-  // 버튼 텍스트 변경
-  elements.submitButton.innerHTML = `<img src="../icons/check.svg" alt="check" />`;
-  elements.submitButton.title = "수정 완료";
-
   // 유효성 검사 실행
-  validateForm(getRequiredFields(elements), elements.submitButton);
+  validateForm(
+    [dateInput, amountInput, contentInput, paymentMethodSelect, categorySelect],
+    submitButton
+  );
 }
 
 // 수정 모드 초기화 함수
@@ -286,6 +290,11 @@ export function renderInputBar(container) {
 
     // 거래내역 목록 업데이트
     const { isIncomeChecked, isExpenseChecked } = getFilteringState();
+    renderMonthlyInfo(
+      document.querySelector("#monthly-info-container"),
+      isIncomeChecked,
+      isExpenseChecked
+    );
     renderTransactionList(isIncomeChecked, isExpenseChecked);
   });
 }

--- a/components/inputBar.js
+++ b/components/inputBar.js
@@ -198,6 +198,10 @@ export function fillFormWithTransaction(transaction) {
 export function resetEditMode() {
   isEditMode = false;
   editingTransactionId = null;
+
+  // 선택된 행 스타일 초기화
+  const selectedRows = document.querySelectorAll(".transaction-row.selected");
+  selectedRows.forEach((row) => row.classList.remove("selected"));
 }
 
 function validateForm(requiredFields, submitButton) {
@@ -256,6 +260,11 @@ export function renderInputBar(container) {
     } else {
       // 추가 모드: 새로운 거래내역 추가
       addNewTransaction(getCurrentYear(), getCurrentMonth(), data);
+      // 새로운 거래내역 추가 시 선택 상태 초기화
+      const selectedRows = document.querySelectorAll(
+        ".transaction-row.selected"
+      );
+      selectedRows.forEach((row) => row.classList.remove("selected"));
     }
 
     // 폼 초기화

--- a/components/inputBar.js
+++ b/components/inputBar.js
@@ -43,8 +43,8 @@ function getFormElements(form) {
 function updateAmountToggleIcon(amountToggle, isPositive) {
   const icon = isPositive ? "plus.svg" : "minus.svg";
   const sign = isPositive ? "+" : "-";
-  amountToggle.src = `../icons/${icon}`;
-  amountToggle.alt = sign;
+  amountToggle.querySelector("img").src = `../icons/${icon}`;
+  amountToggle.querySelector("img").alt = sign;
   amountToggle.dataset.sign = sign;
 }
 

--- a/components/monthlyInfo.js
+++ b/components/monthlyInfo.js
@@ -60,7 +60,7 @@ export function createMonthlyInfo(
     <div class="flex-between light-12">
       <div class="totalCount"></div>
       <div class="flex-row">
-      <label class="custom-checkbox flex-row">
+      <label class="custom-checkbox income-checkbox-label flex-row">
         <input
           type="checkbox"
           name="income"
@@ -77,7 +77,7 @@ export function createMonthlyInfo(
         </span>
         <div>수입 ${formatMoney(monthlyTotalIncome)}</div>
       </label>
-      <label class="custom-checkbox flex-row">
+      <label class="custom-checkbox expense-checkbox-label flex-row">
         <input
           type="checkbox"
           name="expense"
@@ -119,14 +119,19 @@ export function renderMonthlyInfo(
 }
 
 function setupMonthlyInfoEventListeners(container, monthlyData) {
-  const incomeCheckbox = container.querySelector("input[name='income']");
-  const expenseCheckbox = container.querySelector("input[name='expense']");
-  const incomeIcon = container
-    .querySelector("input[name='income']")
-    .parentElement.querySelector(".checkbox-icon");
-  const expenseIcon = container
-    .querySelector("input[name='expense']")
-    .parentElement.querySelector(".checkbox-icon");
+  const incomeCheckboxLabel = container.querySelector(".income-checkbox-label");
+  const expenseCheckboxLabel = container.querySelector(
+    ".expense-checkbox-label"
+  );
+  const incomeIcon = incomeCheckboxLabel.querySelector(".checkbox-icon");
+  const expenseIcon = expenseCheckboxLabel.querySelector(".checkbox-icon");
+
+  const incomeCheckbox = incomeCheckboxLabel.querySelector(
+    "input[name='income']"
+  );
+  const expenseCheckbox = expenseCheckboxLabel.querySelector(
+    "input[name='expense']"
+  );
 
   if (incomeCheckbox && expenseCheckbox) {
     function updateCheckbox() {

--- a/components/monthlyInfo.js
+++ b/components/monthlyInfo.js
@@ -7,6 +7,47 @@ import { setFilteringState } from "../pages.js";
 import { renderTransactionList } from "./transactionsList.js";
 import { formatMoney } from "../utils/format.js";
 
+// totalCount 텍스트를 생성하는 함수
+function createTotalCountText(isIncomeChecked, isExpenseChecked, monthlyData) {
+  const {
+    monthlyTotalCount,
+    monthlyTotalIncomeCount,
+    monthlyTotalExpenseCount,
+  } = monthlyData;
+
+  if (isIncomeChecked && !isExpenseChecked) {
+    // 수입만 체크된 경우: 수입 내역
+    return `<div class="totalCount">수입 내역 ${monthlyTotalIncomeCount}건</div>`;
+  }
+  if (!isIncomeChecked && isExpenseChecked) {
+    // 지출만 체크된 경우: 지출 내역
+    return `<div class="totalCount">지출 내역 ${monthlyTotalExpenseCount}건</div>`;
+  }
+  if (isIncomeChecked && isExpenseChecked) {
+    // 둘 다 체크된 경우: 전체 내역
+    return `<div class="totalCount">전체 내역 ${monthlyTotalCount}건</div>`;
+  }
+  // 둘 다 체크 해제된 경우: 전체 내역 0건
+  return `<div class="totalCount">전체 내역 0건</div>`;
+}
+
+// totalCount를 렌더링하는 함수
+export function renderTotalCount(
+  container,
+  isIncomeChecked,
+  isExpenseChecked,
+  monthlyData
+) {
+  const totalCountElement = container.querySelector(".totalCount");
+  if (totalCountElement) {
+    totalCountElement.innerHTML = createTotalCountText(
+      isIncomeChecked,
+      isExpenseChecked,
+      monthlyData
+    );
+  }
+}
+
 export function createMonthlyInfo(
   monthlyData,
   isIncomeChecked,
@@ -17,7 +58,7 @@ export function createMonthlyInfo(
 
   const monthlyInfoTemplate = `
     <div class="flex-between light-12">
-      <div class="totalCount">전체 내역 ${monthlyTotalCount}건</div>
+      <div class="totalCount"></div>
       <div class="flex-row">
       <label class="custom-checkbox flex-row">
         <input
@@ -86,15 +127,8 @@ function setupMonthlyInfoEventListeners(container, monthlyData) {
   const expenseIcon = container
     .querySelector("input[name='expense']")
     .parentElement.querySelector(".checkbox-icon");
-  const totalCountElement = container.querySelector(".totalCount");
 
-  if (incomeCheckbox && expenseCheckbox && totalCountElement) {
-    const {
-      monthlyTotalCount,
-      monthlyTotalIncomeCount,
-      monthlyTotalExpenseCount,
-    } = monthlyData;
-
+  if (incomeCheckbox && expenseCheckbox) {
     function updateCheckbox() {
       const isIncomeChecked = incomeCheckbox.checked;
       const isExpenseChecked = expenseCheckbox.checked;
@@ -111,20 +145,13 @@ function setupMonthlyInfoEventListeners(container, monthlyData) {
       setFilteringState(isIncomeChecked, isExpenseChecked);
       renderTransactionList(isIncomeChecked, isExpenseChecked);
 
-      // 체크박스 따라 내역 변경되지 않는 문제 수정 필요
-      if (isIncomeChecked && !isExpenseChecked) {
-        // 수입만 체크된 경우: 수입 내역
-        totalCountElement.textContent = `수입 내역 ${monthlyTotalIncomeCount}건`;
-      } else if (!isIncomeChecked && isExpenseChecked) {
-        // 지출만 체크된 경우: 지출 내역
-        totalCountElement.textContent = `지출 내역 ${monthlyTotalExpenseCount}건`;
-      } else if (isIncomeChecked && isExpenseChecked) {
-        // 둘 다 체크된 경우: 수입 내역 + 지출 내역
-        totalCountElement.textContent = `전체 내역 ${monthlyTotalCount}건`;
-      } else {
-        // 둘 다 체크 해제된 경우: 전체 내역
-        totalCountElement.textContent = `전체 내역 0건`;
-      }
+      // totalCount 업데이트
+      renderTotalCount(
+        container,
+        isIncomeChecked,
+        isExpenseChecked,
+        monthlyData
+      );
     }
 
     // 수입 체크박스 이벤트

--- a/components/transactionsList.js
+++ b/components/transactionsList.js
@@ -51,6 +51,31 @@ function registerExternalClickHandler() {
   }
 }
 
+function createTransactionRow(transaction) {
+  return `
+    <tr class="transaction-row" data-id="${transaction.id}">
+      <td class="td-category light-12 category-${
+        CATEGORY_NAME[transaction.category] || CATEGORY_NAME["미분류"]
+      }">${transaction.category}</td>
+      <td class="td-description light-14">${transaction.description}</td>
+      <td class="td-payment-method light-14">${transaction.paymentMethod}</td>
+      <td class="td-amount light-14 ${
+        transaction.amount > 0 ? "text-income" : "text-expense"
+      }">
+        ${formatMoney(transaction.amount)}원
+        <button 
+          class="delete-btn flex-row semibold-14" 
+          data-id="${transaction.id}">
+          <div class="delete-btn-icon">
+            <img src="../icons/closed.svg" alt="delete" />
+          </div>
+          <div>삭제</div>
+        </button>
+      </td>
+    </tr>
+  `;
+}
+
 export function createTransactionList(isIncomeChecked, isExpenseChecked) {
   const transactionListByYearMonth = getTransactionsByYearMonth(
     getCurrentYear(),
@@ -105,34 +130,10 @@ export function createTransactionList(isIncomeChecked, isExpenseChecked) {
         </div>
       `;
 
-      const rows = transactionList
-        .map(
-          (transaction) => `
-        <tr class="transaction-row" data-id="${transaction.id}">
-          <td class="td-category light-12 category-${
-            CATEGORY_NAME[transaction.category] || CATEGORY_NAME["미분류"]
-          }">${transaction.category}</td>
-          <td class="td-description light-14">${transaction.description}</td>
-          <td class="td-payment-method light-14">${
-            transaction.paymentMethod
-          }</td>
-          <td class="td-amount light-14 ${
-            transaction.amount > 0 ? "text-income" : "text-expense"
-          }">${formatMoney(transaction.amount)}원
-            <button 
-                class="delete-btn flex-row semibold-14" 
-                data-id="${transaction.id}"
-                >
-                <div class="delete-btn-icon">
-                  <img src="../icons/closed.svg" alt="delete" />
-                </div>
-                <div>삭제</div>
-            </button>
-          </td>
-        </tr> 
-      `
-        )
-        .join("");
+      const rows = transactionList.reduce((acc, transaction) => {
+        const row = createTransactionRow(transaction);
+        return acc + row;
+      }, "");
 
       return `
         ${header}

--- a/components/transactionsList.js
+++ b/components/transactionsList.js
@@ -10,6 +10,7 @@ import { CATEGORY_NAME } from "../constants/category.js";
 import { formatMoney } from "../utils/format.js";
 import { fillFormWithTransaction, cancelEditMode } from "./inputBar.js";
 import { renderMonthlyInfo, renderTotalCount } from "./monthlyInfo.js";
+import { renderCalendar, renderCalendarInfo } from "./calendar.js";
 
 // 클릭된 행 상태 관리
 let selectedRowId = null;
@@ -184,6 +185,17 @@ export function renderTransactionList(isIncomeChecked, isExpenseChecked) {
           )
         );
         renderTransactionList(isIncomeChecked, isExpenseChecked);
+
+        const calendarContainer = document.querySelector(".calendar-container");
+        if (calendarContainer) {
+          renderCalendar(calendarContainer);
+        }
+        const calendarInfoContainer = document.querySelector(
+          ".calendar-info-container"
+        );
+        if (calendarInfoContainer) {
+          renderCalendarInfo(calendarInfoContainer);
+        }
       });
     });
 

--- a/components/transactionsList.js
+++ b/components/transactionsList.js
@@ -6,7 +6,7 @@ import {
   monthlyTotalData,
 } from "../utils/transaction.js";
 import { getCurrentYear, getCurrentMonth } from "../utils/currentDate.js";
-import { CATEGORY_NAME } from "../constants/categoryName.js";
+import { CATEGORY_NAME } from "../constants/category.js";
 import { formatMoney } from "../utils/format.js";
 import { fillFormWithTransaction, cancelEditMode } from "./inputBar.js";
 import { renderMonthlyInfo, renderTotalCount } from "./monthlyInfo.js";
@@ -109,7 +109,7 @@ export function createTransactionList(isIncomeChecked, isExpenseChecked) {
           (transaction) => `
         <tr class="transaction-row" data-id="${transaction.id}">
           <td class="td-category light-12 category-${
-            CATEGORY_NAME[transaction.category]
+            CATEGORY_NAME[transaction.category] || CATEGORY_NAME["미분류"]
           }">${transaction.category}</td>
           <td class="td-description light-14">${transaction.description}</td>
           <td class="td-payment-method light-14">${

--- a/components/transactionsList.js
+++ b/components/transactionsList.js
@@ -8,6 +8,7 @@ import { getCurrentYear, getCurrentMonth } from "../utils/currentDate.js";
 import { CATEGORY_NAME } from "../constants/categoryName.js";
 import { formatMoney } from "../utils/format.js";
 import { fillFormWithTransaction, cancelEditMode } from "./inputBar.js";
+import { renderMonthlyInfo } from "./monthlyInfo.js";
 
 // 클릭된 행 상태 관리
 let selectedRowId = null;
@@ -163,6 +164,12 @@ export function renderTransactionList(isIncomeChecked, isExpenseChecked) {
         deleteTransaction(getCurrentYear(), getCurrentMonth(), id);
         // 삭제 후 선택 상태 초기화
         selectedRowId = null;
+        //왜 안될까...
+        renderMonthlyInfo(
+          document.getElementById("monthly-info-container"),
+          isIncomeChecked,
+          isExpenseChecked
+        );
         renderTransactionList(isIncomeChecked, isExpenseChecked);
       });
     });

--- a/components/transactionsList.js
+++ b/components/transactionsList.js
@@ -115,7 +115,9 @@ export function createTransactionList(isIncomeChecked, isExpenseChecked) {
           <td class="td-payment-method light-14">${
             transaction.paymentMethod
           }</td>
-          <td class="td-amount light-14">${formatMoney(transaction.amount)}원
+          <td class="td-amount light-14 ${
+            transaction.amount > 0 ? "text-income" : "text-expense"
+          }">${formatMoney(transaction.amount)}원
             <button 
                 class="delete-btn flex-row semibold-14" 
                 data-id="${transaction.id}"

--- a/components/transactionsList.js
+++ b/components/transactionsList.js
@@ -3,12 +3,13 @@ import {
   groupTransactionsByDate,
   deleteTransaction,
   getTransactionById,
+  monthlyTotalData,
 } from "../utils/transaction.js";
 import { getCurrentYear, getCurrentMonth } from "../utils/currentDate.js";
 import { CATEGORY_NAME } from "../constants/categoryName.js";
 import { formatMoney } from "../utils/format.js";
 import { fillFormWithTransaction, cancelEditMode } from "./inputBar.js";
-import { renderMonthlyInfo } from "./monthlyInfo.js";
+import { renderMonthlyInfo, renderTotalCount } from "./monthlyInfo.js";
 
 // 클릭된 행 상태 관리
 let selectedRowId = null;
@@ -164,11 +165,21 @@ export function renderTransactionList(isIncomeChecked, isExpenseChecked) {
         deleteTransaction(getCurrentYear(), getCurrentMonth(), id);
         // 삭제 후 선택 상태 초기화
         selectedRowId = null;
-        //왜 안될까...
+        const monthlyInfoContainer = document.querySelector(
+          "#monthly-info-container"
+        );
         renderMonthlyInfo(
-          document.getElementById("monthly-info-container"),
+          monthlyInfoContainer,
           isIncomeChecked,
           isExpenseChecked
+        );
+        renderTotalCount(
+          monthlyInfoContainer,
+          isIncomeChecked,
+          isExpenseChecked,
+          monthlyTotalData(
+            getTransactionsByYearMonth(getCurrentYear(), getCurrentMonth())
+          )
         );
         renderTransactionList(isIncomeChecked, isExpenseChecked);
       });

--- a/components/transactionsList.js
+++ b/components/transactionsList.js
@@ -2,10 +2,12 @@ import {
   getTransactionsByYearMonth,
   groupTransactionsByDate,
   deleteTransaction,
+  getTransactionById,
 } from "../utils/transaction.js";
 import { getCurrentYear, getCurrentMonth } from "../utils/currentDate.js";
 import { CATEGORY_NAME } from "../constants/categoryName.js";
 import { formatMoney } from "../utils/format.js";
+import { fillFormWithTransaction } from "./inputBar.js";
 
 export function createTransactionList(isIncomeChecked, isExpenseChecked) {
   const transactionListByYearMonth = getTransactionsByYearMonth(
@@ -64,7 +66,7 @@ export function createTransactionList(isIncomeChecked, isExpenseChecked) {
       const rows = transactionList
         .map(
           (transaction) => `
-        <tr>
+        <tr class="transaction-row" data-id="${transaction.id}">
           <td class="td-category light-12 category-${
             CATEGORY_NAME[transaction.category]
           }">${transaction.category}</td>
@@ -116,11 +118,35 @@ export function renderTransactionList(isIncomeChecked, isExpenseChecked) {
 
     // 삭제 버튼 이벤트 리스너 추가
     transactionListContainer.querySelectorAll(".delete-btn").forEach((btn) => {
-      btn.addEventListener("click", () => {
+      btn.addEventListener("click", (e) => {
+        e.stopPropagation(); // 행 클릭 이벤트 방지
         const id = Number(btn.dataset.id);
         deleteTransaction(getCurrentYear(), getCurrentMonth(), id);
         renderTransactionList(isIncomeChecked, isExpenseChecked);
       });
     });
+
+    // 거래내역 행 클릭 이벤트 리스너 추가
+    transactionListContainer
+      .querySelectorAll(".transaction-row")
+      .forEach((row) => {
+        row.addEventListener("click", (e) => {
+          // 삭제 버튼 클릭 시에는 행 클릭 이벤트 실행하지 않음
+          if (e.target.closest(".delete-btn")) {
+            return;
+          }
+
+          const id = Number(row.dataset.id);
+          const transaction = getTransactionById(
+            getCurrentYear(),
+            getCurrentMonth(),
+            id
+          );
+
+          if (transaction) {
+            fillFormWithTransaction(transaction);
+          }
+        });
+      });
   }
 }

--- a/components/transactionsList.js
+++ b/components/transactionsList.js
@@ -9,6 +9,22 @@ import { CATEGORY_NAME } from "../constants/categoryName.js";
 import { formatMoney } from "../utils/format.js";
 import { fillFormWithTransaction } from "./inputBar.js";
 
+// 클릭된 행 상태 관리
+let selectedRowId = null;
+
+// 선택된 행의 스타일을 업데이트하는 함수
+function updateSelectedRowStyle(selectedRowId) {
+  const allRows = document.querySelectorAll(".transaction-row");
+  allRows.forEach((row) => {
+    const rowId = Number(row.dataset.id);
+    if (rowId === selectedRowId) {
+      row.classList.add("selected");
+    } else {
+      row.classList.remove("selected");
+    }
+  });
+}
+
 export function createTransactionList(isIncomeChecked, isExpenseChecked) {
   const transactionListByYearMonth = getTransactionsByYearMonth(
     getCurrentYear(),
@@ -122,6 +138,8 @@ export function renderTransactionList(isIncomeChecked, isExpenseChecked) {
         e.stopPropagation(); // 행 클릭 이벤트 방지
         const id = Number(btn.dataset.id);
         deleteTransaction(getCurrentYear(), getCurrentMonth(), id);
+        // 삭제 후 선택 상태 초기화
+        selectedRowId = null;
         renderTransactionList(isIncomeChecked, isExpenseChecked);
       });
     });
@@ -144,6 +162,9 @@ export function renderTransactionList(isIncomeChecked, isExpenseChecked) {
           );
 
           if (transaction) {
+            // 선택된 행 업데이트
+            selectedRowId = id;
+            updateSelectedRowStyle(selectedRowId);
             fillFormWithTransaction(transaction);
           }
         });

--- a/constants/category.js
+++ b/constants/category.js
@@ -10,3 +10,15 @@ export const CATEGORY_NAME = {
   "기타 수입": "etc-income",
   용돈: "allowance",
 };
+
+export const INCOME_CATEGORIES = ["월급", "용돈", "기타  수입"];
+
+export const EXPENSE_CATEGORIES = [
+  "생활",
+  "식비",
+  "교통",
+  "쇼핑/뷰티",
+  "의료/건강",
+  "문화/여가",
+  "미분류",
+];

--- a/pages.js
+++ b/pages.js
@@ -9,6 +9,7 @@ import {
   monthlyTotalData,
 } from "./utils/transaction.js";
 import { getCurrentYear, getCurrentMonth } from "./utils/currentDate.js";
+import { renderCalendar } from "./components/calendar.js";
 
 let isIncomeChecked = true;
 let isExpenseChecked = true;
@@ -34,8 +35,8 @@ export function createMainPage() {
 
 export function createCalendarPage() {
   return `
-    <div class="calendar-page">
-      <h2>캘린더</h2>
+    <div class="container">
+      <div class="calendar-container"></div>
     </div>
   `;
 }
@@ -87,6 +88,11 @@ export function renderCalendarPage() {
   const mainContainer = document.getElementById("main-container");
   if (mainContainer) {
     mainContainer.innerHTML = createCalendarPage();
+  }
+
+  const calendarContainer = mainContainer.querySelector(".calendar-container");
+  if (calendarContainer) {
+    renderCalendar(calendarContainer);
   }
 }
 

--- a/pages.js
+++ b/pages.js
@@ -9,7 +9,7 @@ import {
   monthlyTotalData,
 } from "./utils/transaction.js";
 import { getCurrentYear, getCurrentMonth } from "./utils/currentDate.js";
-import { renderCalendar } from "./components/calendar.js";
+import { renderCalendar, renderCalendarInfo } from "./components/calendar.js";
 
 let isIncomeChecked = true;
 let isExpenseChecked = true;
@@ -37,6 +37,7 @@ export function createCalendarPage() {
   return `
     <div class="container">
       <div class="calendar-container"></div>
+      <div class="calendar-info-container"></div>
     </div>
   `;
 }
@@ -93,6 +94,12 @@ export function renderCalendarPage() {
   const calendarContainer = mainContainer.querySelector(".calendar-container");
   if (calendarContainer) {
     renderCalendar(calendarContainer);
+  }
+  const calendarInfoContainer = mainContainer.querySelector(
+    ".calendar-info-container"
+  );
+  if (calendarInfoContainer) {
+    renderCalendarInfo(calendarInfoContainer);
   }
 }
 

--- a/pages.js
+++ b/pages.js
@@ -1,6 +1,14 @@
-import { renderMonthlyInfo } from "./components/monthlyInfo.js";
+import {
+  renderMonthlyInfo,
+  renderTotalCount,
+} from "./components/monthlyInfo.js";
 import { renderInputBar } from "./components/inputBar.js";
 import { renderTransactionList } from "./components/transactionsList.js";
+import {
+  getTransactionsByYearMonth,
+  monthlyTotalData,
+} from "./utils/transaction.js";
+import { getCurrentYear, getCurrentMonth } from "./utils/currentDate.js";
 
 let isIncomeChecked = true;
 let isExpenseChecked = true;
@@ -62,6 +70,14 @@ export function renderMainPage() {
   );
   if (monthlyInfoContainer) {
     renderMonthlyInfo(monthlyInfoContainer, isIncomeChecked, isExpenseChecked);
+    renderTotalCount(
+      monthlyInfoContainer,
+      isIncomeChecked,
+      isExpenseChecked,
+      monthlyTotalData(
+        getTransactionsByYearMonth(getCurrentYear(), getCurrentMonth())
+      )
+    );
   }
 
   renderTransactionList(isIncomeChecked, isExpenseChecked);

--- a/store/transactionsStore.js
+++ b/store/transactionsStore.js
@@ -1,5 +1,39 @@
 export const transactionsData = {
   2025: {
+    1: [
+      {
+        id: 12,
+        date: "2025-01-15",
+        category: "식비",
+        description: "점심 식사",
+        paymentMethod: "현금",
+        amount: -12000,
+      },
+      {
+        id: 13,
+        date: "2025-01-14",
+        category: "교통",
+        description: "지하철 교통비",
+        paymentMethod: "카드",
+        amount: -1350,
+      },
+      {
+        id: 14,
+        date: "2025-01-13",
+        category: "쇼핑/뷰티",
+        description: "화장품 구매",
+        paymentMethod: "카드",
+        amount: -45000,
+      },
+      {
+        id: 15,
+        date: "2025-01-12",
+        category: "월급",
+        description: "1월 급여",
+        paymentMethod: "현금",
+        amount: 2500000,
+      },
+    ],
     7: [
       {
         id: 1,
@@ -19,22 +53,6 @@ export const transactionsData = {
       },
       {
         id: 3,
-        date: "2025-07-09",
-        category: "식비",
-        description: "두유 4개",
-        paymentMethod: "현대카드",
-        amount: -19140,
-      },
-      {
-        id: 4,
-        date: "2025-07-09",
-        category: "생활",
-        description: "7월 월세",
-        paymentMethod: "현대카드",
-        amount: -500000,
-      },
-      {
-        id: 5,
         date: "2025-07-13",
         category: "식비",
         description: "잔치국수와 김밥",
@@ -42,12 +60,28 @@ export const transactionsData = {
         amount: -10000,
       },
       {
-        id: 6,
+        id: 4,
         date: "2025-07-13",
         category: "월급",
         description: "7월 급여",
         paymentMethod: "현금",
         amount: 2010580,
+      },
+      {
+        id: 5,
+        date: "2025-07-09",
+        category: "식비",
+        description: "두유 4개",
+        paymentMethod: "현대카드",
+        amount: -19140,
+      },
+      {
+        id: 6,
+        date: "2025-07-09",
+        category: "생활",
+        description: "7월 월세",
+        paymentMethod: "현대카드",
+        amount: -500000,
       },
     ],
     6: [

--- a/styles.css
+++ b/styles.css
@@ -546,10 +546,15 @@ table {
   height: 12px;
 }
 
-tr:hover .delete-btn {
+.transaction-row:hover .delete-btn {
   display: flex;
 }
 
-tr:hover {
+.transaction-row {
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.transaction-row:hover {
   background-color: var(--nuetral-surface-point);
 }

--- a/styles.css
+++ b/styles.css
@@ -209,6 +209,10 @@ header {
   align-items: center;
 }
 
+.gap-8 {
+  gap: 8px;
+}
+
 .input-bar {
   width: 894px;
   height: 112px;
@@ -575,8 +579,8 @@ table {
 
 /* calendar */
 .calendar-container {
-  border-left: 1px solid var(--nuetral-border-default);
   border-top: 1px solid var(--nuetral-border-default);
+  border-left: 1px solid var(--nuetral-border-default);
   width: 100%;
   background: var(--nuetral-surface-default);
   overflow: hidden;

--- a/styles.css
+++ b/styles.css
@@ -212,6 +212,7 @@ header {
 .input-bar {
   width: 894px;
   height: 112px;
+  margin: 0 auto 40px;
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -221,7 +222,7 @@ header {
 
 .container {
   width: 846px;
-  margin: 40px auto 0;
+  margin: 0 auto;
   gap: 20px;
   display: flex;
   flex-direction: column;
@@ -570,4 +571,72 @@ table {
 
 .transaction-row.selected .delete-btn {
   display: flex;
+}
+
+/* calendar */
+.calendar-container {
+  border-left: 1px solid var(--nuetral-border-default);
+  border-top: 1px solid var(--nuetral-border-default);
+  width: 100%;
+  background: var(--nuetral-surface-default);
+  overflow: hidden;
+}
+
+.calendar-header {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  text-align: center;
+  height: 48px;
+}
+
+.calendar-header > div {
+  border-right: 1px solid var(--nuetral-border-default);
+  border-bottom: 1px solid var(--nuetral-border-default);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.calendar-row {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  text-align: right;
+  height: 120px;
+}
+
+.calendar-cell {
+  cursor: pointer;
+  transition: background 0.2s;
+  border-right: 1px solid var(--nuetral-border-default);
+  border-bottom: 1px solid var(--nuetral-border-default);
+  display: flex;
+  flex-direction: column;
+}
+
+.calendar-cell:hover {
+  background: var(--nuetral-surface-point);
+}
+
+.calendar-cell.empty {
+  background: none;
+  cursor: default;
+}
+
+.calendar-cell-details {
+  height: 100%;
+  padding: 8px 8px;
+  display: flex;
+  flex-direction: column;
+}
+
+.calendar-amount {
+  height: 24px;
+  display: flex;
+  justify-content: left;
+  align-items: center;
+}
+
+.calendar-date {
+  padding: 8px 8px;
+  text-align: right;
 }

--- a/styles.css
+++ b/styles.css
@@ -462,7 +462,7 @@ table {
   height: 56px;
   text-align: center;
   vertical-align: middle;
-  background-color: var(--danger-surface-default);
+  background-color: var(--pastel-lavenderPink);
 }
 
 .category-life {
@@ -493,8 +493,13 @@ table {
 .category-etc-income {
   background: var(--colorchip-10);
 }
-.category-etc-expense {
-  background: var(--colorchip-40);
+
+.text-expense {
+  color: var(--brand-text-expense);
+}
+
+.text-income {
+  color: var(--brand-text-income);
 }
 
 .td-description {

--- a/styles.css
+++ b/styles.css
@@ -558,3 +558,11 @@ table {
 .transaction-row:hover {
   background-color: var(--nuetral-surface-point);
 }
+
+.transaction-row.selected {
+  background-color: var(--nuetral-surface-point);
+}
+
+.transaction-row.selected .delete-btn {
+  display: flex;
+}

--- a/utils/currentDate.js
+++ b/utils/currentDate.js
@@ -1,4 +1,4 @@
-import { renderMainPage } from "../pages.js";
+import { render } from "./routes.js";
 
 // 현재 날짜 상태 관리
 let currentDate = new Date();
@@ -76,7 +76,7 @@ export function setupDateEventListeners(container) {
     prevMonthBtn.addEventListener("click", () => {
       goToPreviousMonth();
       renderHeaderDate();
-      renderMainPage();
+      render();
     });
   }
 
@@ -84,7 +84,7 @@ export function setupDateEventListeners(container) {
     nextMonthBtn.addEventListener("click", () => {
       goToNextMonth();
       renderHeaderDate();
-      renderMainPage();
+      render();
     });
   }
 }

--- a/utils/transaction.js
+++ b/utils/transaction.js
@@ -118,3 +118,36 @@ export function monthlyTotalData(transactions) {
     monthlyTotalExpenseCount,
   };
 }
+
+export function dailyTotalData(transactions) {
+  const dailyTotalIncomeTransactions = transactions.filter(
+    (transaction) => transaction.amount > 0
+  );
+  const dailyTotalExpenseTransactions = transactions.filter(
+    (transaction) => transaction.amount < 0
+  );
+  const dailyTotalIncome = dailyTotalIncomeTransactions.reduce(
+    (sum, transaction) => sum + transaction.amount,
+    0
+  );
+  const dailyTotalExpense = dailyTotalExpenseTransactions.reduce(
+    (sum, transaction) => sum + transaction.amount,
+    0
+  );
+  const dailyTotalCount =
+    dailyTotalIncomeTransactions.length + dailyTotalExpenseTransactions.length;
+
+  const dailyTotalIncomeCount = dailyTotalIncomeTransactions.length;
+
+  const dailyTotalExpenseCount = dailyTotalExpenseTransactions.length;
+
+  const dailyTotalAmount = dailyTotalIncome + dailyTotalExpense;
+  return {
+    dailyTotalIncome,
+    dailyTotalExpense,
+    dailyTotalCount,
+    dailyTotalIncomeCount,
+    dailyTotalExpenseCount,
+    dailyTotalAmount,
+  };
+}

--- a/utils/transaction.js
+++ b/utils/transaction.js
@@ -44,12 +44,12 @@ export function addNewTransaction(year, month, formData) {
 
 //기존 거래 내역 삭제
 export function deleteTransaction(year, month, id) {
+  alert(`거래내역 ID ${id}을 삭제하시겠습니까?`);
   const index = transactionsData[year][month].findIndex(
     (transaction) => transaction.id === id
   );
   if (index !== -1) {
     transactionsData[year][month].splice(index, 1);
-    alert(`거래내역 ID ${id}가 삭제되었습니다.`);
   } else {
     alert(`거래내역 ID ${id} 삭제에 실패했습니다.`);
   }

--- a/utils/transaction.js
+++ b/utils/transaction.js
@@ -23,7 +23,7 @@ export function groupTransactionsByDate(transactions) {
 // 새로운 거래내역 추가
 export function addNewTransaction(year, month, formData) {
   const newTransaction = {
-    id: transactionsData.length + 1,
+    id: new Date().getTime() + Math.random(),
     date: formData.date,
     amount: parseInt(formData.amount),
     description: formData.content,

--- a/utils/transaction.js
+++ b/utils/transaction.js
@@ -55,6 +55,40 @@ export function deleteTransaction(year, month, id) {
   }
 }
 
+// 거래내역 수정
+export function updateTransaction(year, month, id, formData) {
+  const index = transactionsData[year][month].findIndex(
+    (transaction) => transaction.id === id
+  );
+  if (index !== -1) {
+    transactionsData[year][month][index] = {
+      ...transactionsData[year][month][index],
+      date: formData.date,
+      amount: parseInt(formData.amount),
+      description: formData.content,
+      paymentMethod: formData.paymentMethod,
+      category: formData.category,
+    };
+
+    // 날짜순으로 정렬
+    transactionsData[year][month].sort(
+      (a, b) => new Date(b.date) - new Date(a.date)
+    );
+
+    return transactionsData[year][month][index];
+  } else {
+    alert(`거래내역 ID ${id} 수정에 실패했습니다.`);
+    return null;
+  }
+}
+
+// 특정 ID의 거래내역 조회
+export function getTransactionById(year, month, id) {
+  return transactionsData[year][month].find(
+    (transaction) => transaction.id === id
+  );
+}
+
 // 월별 수입 건수, 총합, 지출 건수, 총합, 총 건수 계산
 export function monthlyTotalData(transactions) {
   const monthlyTotalIncomeTransactions = transactions.filter(


### PR DESCRIPTION

## 완료 작업 목록

- 수정 기능 구현
  -  해당 row를 클릭 시 그 row의 데이터대로 form이 채워지고, 내역을 수정할 수 있습니다
- 캘린더 구현
  - 거래 내역 추가, 수정, 삭제 시 캘린더 화면 업데이트

https://github.com/user-attachments/assets/9a56b007-f876-4005-85ac-b6c9641a82ae


## 주요 고민과 해결 과정

inputBar.js 파일에 너무 많은 함수가 들어있어 가독성이 좋지 않은데 어떻게 정리하는 게 좋을지 고민 중입니다.
거래 내역을 추가, 수정, 삭제 할 때 마다 거래 내역 리스트와 캘린더를 함께 리렌더링 해야 하는데, 어떻게 해야 한번에 처리할 수 있을 지 고민이 됩니다. 옵저버 패턴에 대해 공부해보아야할 것 같습니다.

### view를 순수하게 유지하기
캘린더를 구현하던 중, 어떻게 하면 view를 순수하게 유지할 수 있을 지에 대해 고민했습니다..
renderCalendar 함수 내에서, 각 날짜마다 거래 내역 리스트를 불러와 수입 지출 총합을 계산하는 것이 아니라, 수입 지출 총합만을 계산하는 함수를 외부로 분리하는 방식으로 구현했습니다. 

현재 2차원 배열을 생성하고 이를 기반으로 캘린더를 만들고 있는데, 2차원 배열 생성 함수도 분리하여 캘린더 파일에서는 오로지 ui기능만 할 수 있도록 수정할 계획입니다.

### map.join vs reduce
크롱의 코멘트로 map.join과 reduce의 차이에 대해 알아보았습니다.

reduce는 보통 배열의 총합을 구할 때 자주 사용하곤 하는 메서드인데, 문자열의 총합도 반환이 가능합니다.

같은 코드를 map, reduce로 작성했을 때 아래와 같은 차이가 있는데요,
```jsx
const rows = transactionList.map(
	(transaction) => createTransactionRow(transaction)
        )
        .join("");
```
```jsx
const rows = transactionList.reduce((acc, transaction) => {
        const row = createTransactionRow(transaction);
        return acc + row;
      }, "");
```
#### `.map().join("")` 방식

1. `map()` → `["<li>A</li>", "<li>B</li>", "<li>C</li>"]` (배열 생성)
2. `join("")` → `"<li>A</li><li>B</li><li>C</li>"` 

map()은 기존 배열을 하나씩 매핑하며 새로운 배열을 만들고고 join에서 새로운 배열을 합치는 방식으로 작동합니다.

#### `.reduce()` 방식

1. `reduce()` → `"".concat("<li>A</li>").concat("<li>B</li>").concat("<li>C</li>")`
    → 새로운 배열을 생성하지 않고, 초기값으로 설정해둔 “”에 생성한 row를 바로 더해서 붙입니다.

항목 수가 적을 경우에는 map.join이 직관적이지만, 배열의 크기가 크면 클 수록 reduce가 더 적은 메모리를 소요하여 효율적이라고 합니다.

reduce와 map/join의 성능을 for, for of와 함께 비교해볼 수 있는 사이트를 찾았는데, 똑같이 문자열 배열의 값을 수정해서 새로운 문자열을 만드는 경우 reduce가 가장 빠르고 map이 가장 느리다고 하네요. 궁금하신 분은 한번 둘러보세요

https://www.measurethat.net/Benchmarks/Show/3014/0/reduce-vs-mapjoin

저는 reduce 방식이 더 좋은 것 같아 코드 리팩토링을 했습니다 ㅎㅎ