### PR TITLE
[김민정] - 전역 이벤트 관리자 도입 및 수입지출 업데이트시 무한재귀 문제 고민

### DIFF
--- a/src/assets/closed_white.svg
+++ b/src/assets/closed_white.svg
@@ -1,0 +1,4 @@
+<svg width="8" height="9" viewBox="0 0 8 9" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M2.58582 3.08569L5.41424 5.91412" stroke="white" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M2.58582 5.91431L5.41424 3.08588" stroke="white" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/form/CategoryForm.js
+++ b/src/components/form/CategoryForm.js
@@ -26,7 +26,7 @@ export const CategoryForm = (input) => {
       }.png`;
 
       // 값 업데이트+화면에 표시
-      if (e.target.closest("li")) {
+      if (e.target.closest(".drop-down-li")) {
         const selectedCategory = e.target.innerText;
         input.category = selectedCategory;
         const categoryTextInput =

--- a/src/components/form/CategoryForm.js
+++ b/src/components/form/CategoryForm.js
@@ -17,7 +17,7 @@ export const CategoryForm = (input) => {
   EventDispatcher.register({
     eventType: "click",
     selector: "form-category",
-    handler: (e) => {
+    handler: ({ target }) => {
       // 이미지 업데이트
       const categoryImg = categoryForm.querySelector("#category > img");
       isCategoryOpen = !isCategoryOpen;
@@ -26,9 +26,9 @@ export const CategoryForm = (input) => {
       }.png`;
 
       // 값 업데이트+화면에 표시
-      const dropDownLi = e.target.closest(".drop-down-li");
+      const dropDownLi = target.closest(".drop-down-li");
       if (dropDownLi) {
-        const selectedCategory = e.target.innerText;
+        const selectedCategory = target.innerText;
         input.category = selectedCategory;
         const categoryTextInput =
           categoryForm.querySelector("#category > span");

--- a/src/components/form/CategoryForm.js
+++ b/src/components/form/CategoryForm.js
@@ -26,18 +26,13 @@ export const CategoryForm = (input) => {
       }.png`;
 
       // 값 업데이트+화면에 표시
-      if (e.target.closest(".drop-down-li")) {
+      const dropDownLi = e.target.closest(".drop-down-li");
+      if (dropDownLi) {
         const selectedCategory = e.target.innerText;
         input.category = selectedCategory;
         const categoryTextInput =
           categoryForm.querySelector("#category > span");
         categoryTextInput.textContent = selectedCategory;
-
-        const event = new Event("input", {
-          bubbles: true, // 이벤트 버블링을 허용 -> 상위 entireForm까지 도달
-          cancelable: false,
-        });
-        categoryTextInput.dispatchEvent(event);
       }
 
       // 드롭다운 화면에 표시/제거

--- a/src/components/form/CategoryForm.js
+++ b/src/components/form/CategoryForm.js
@@ -43,7 +43,7 @@ export const CategoryForm = (input) => {
       // 드롭다운 화면에 표시/제거
       if (isCategoryOpen) {
         categoryForm.appendChild(
-          DropDown("category", CATEGORY[input.moneyType])
+          DropDown({ type: "category", data: CATEGORY[input.moneyType] })
         );
       } else {
         const dropDown = categoryForm.querySelector(".drop-down");

--- a/src/components/form/CategoryForm.js
+++ b/src/components/form/CategoryForm.js
@@ -1,4 +1,5 @@
 import { CATEGORY } from "../../constants/category.js";
+import { EventDispatcher } from "../../store/EventBusStore.js";
 import { ElementManager } from "../../utils/ElementManager.js";
 import { DropDown } from "./DropDown.js";
 
@@ -13,35 +14,42 @@ export const CategoryForm = (input) => {
   </button>
   `;
 
-  categoryForm.addEventListener("click", (e) => {
-    // 이미지 업데이트
-    const categoryImg = categoryForm.querySelector("#category > img");
-    isCategoryOpen = !isCategoryOpen;
-    categoryImg.src = `./src/assets/chevron-${
-      isCategoryOpen ? "up" : "down"
-    }.png`;
+  EventDispatcher.register({
+    eventType: "click",
+    selector: "form-category",
+    handler: (e) => {
+      // 이미지 업데이트
+      const categoryImg = categoryForm.querySelector("#category > img");
+      isCategoryOpen = !isCategoryOpen;
+      categoryImg.src = `./src/assets/chevron-${
+        isCategoryOpen ? "up" : "down"
+      }.png`;
 
-    // 값 업데이트+화면에 표시
-    if (e.target.closest("li")) {
-      const selectedCategory = e.target.innerText;
-      input.category = selectedCategory;
-      const categoryTextInput = categoryForm.querySelector("#category > span");
-      categoryTextInput.textContent = selectedCategory;
+      // 값 업데이트+화면에 표시
+      if (e.target.closest("li")) {
+        const selectedCategory = e.target.innerText;
+        input.category = selectedCategory;
+        const categoryTextInput =
+          categoryForm.querySelector("#category > span");
+        categoryTextInput.textContent = selectedCategory;
 
-      const event = new Event("input", {
-        bubbles: true, // 이벤트 버블링을 허용 -> 상위 entireForm까지 도달
-        cancelable: false,
-      });
-      categoryTextInput.dispatchEvent(event);
-    }
+        const event = new Event("input", {
+          bubbles: true, // 이벤트 버블링을 허용 -> 상위 entireForm까지 도달
+          cancelable: false,
+        });
+        categoryTextInput.dispatchEvent(event);
+      }
 
-    // 드롭다운 화면에 표시/제거
-    if (isCategoryOpen) {
-      categoryForm.appendChild(DropDown("category", CATEGORY[input.moneyType]));
-    } else {
-      const dropDown = categoryForm.querySelector(".drop-down");
-      categoryForm.removeChild(dropDown);
-    }
+      // 드롭다운 화면에 표시/제거
+      if (isCategoryOpen) {
+        categoryForm.appendChild(
+          DropDown("category", CATEGORY[input.moneyType])
+        );
+      } else {
+        const dropDown = categoryForm.querySelector(".drop-down");
+        categoryForm.removeChild(dropDown);
+      }
+    },
   });
   return categoryForm;
 };

--- a/src/components/form/ContentForm.js
+++ b/src/components/form/ContentForm.js
@@ -14,6 +14,7 @@ export const ContentForm = (input) => {
   contentInput.addEventListener("input", (e) => {
     input.content = e.target.value;
     contentInputLength.textContent = input.content.length + "/" + maxLength;
+    console.log("a");
   });
   return contentForm;
 };

--- a/src/components/form/DateForm.js
+++ b/src/components/form/DateForm.js
@@ -1,3 +1,4 @@
+import { EventDispatcher } from "../../store/EventBusStore.js";
 import { ElementManager } from "../../utils/ElementManager.js";
 
 export const DateForm = (input) => {
@@ -9,8 +10,12 @@ export const DateForm = (input) => {
   }" class="semibold-12">
   `;
 
-  dateForm.addEventListener("input", (e) => {
-    input.date = new Date(e.target.value);
+  EventDispatcher.register({
+    eventType: "input",
+    selector: "form-date",
+    handler: (e) => {
+      input.date = new Date(e.target.value);
+    },
   });
   return dateForm;
 };

--- a/src/components/form/DropDown.js
+++ b/src/components/form/DropDown.js
@@ -1,6 +1,6 @@
 import { ElementManager } from "../../utils/ElementManager.js";
 
-export const DropDown = (type, data) => {
+export const DropDown = ({ type, data }) => {
   const dropDown = ElementManager.renderElement("ul", "drop-down");
   data.map((partData) => {
     const dropDownList = document.createElement("li");

--- a/src/components/form/FormChecker.js
+++ b/src/components/form/FormChecker.js
@@ -1,10 +1,13 @@
+import { EventDispatcher } from "../../store/EventBusStore.js";
 import { ElementManager } from "../../utils/ElementManager.js";
 import { InputValidator } from "../../utils/InputValidator.js";
 
 export const FormChecker = (input) => {
   const formChecker = ElementManager.renderElement("div", "form-checker");
   formChecker.innerHTML = `
+    <div class="img-wrapper">
       <img src="./src/assets/check.svg" alt="check icon">
+    </div
     `;
 
   formChecker.addEventListener("click", () => {
@@ -19,5 +22,21 @@ export const FormChecker = (input) => {
     }
     console.log(input);
   });
+  // EventDispatcher.register({
+  //   eventType: "click",
+  //   selector: "form-checker",
+  //   handler: () => {
+  //     console.log(input);
+  //     const isFullFilled = InputValidator.validateFullFilled(input);
+  //     if (!isFullFilled) return;
+
+  //     const isFullCorrectType = InputValidator.validateFullCorrectType(input);
+  //     if (isFullCorrectType) {
+  //       console.log("ok");
+  //     } else {
+  //       console.log("no");
+  //     }
+  //   },
+  // });
   return formChecker;
 };

--- a/src/components/form/FormChecker.js
+++ b/src/components/form/FormChecker.js
@@ -7,36 +7,24 @@ export const FormChecker = (input) => {
   formChecker.innerHTML = `
     <div class="img-wrapper">
       <img src="./src/assets/check.svg" alt="check icon">
-    </div
+    </div>
     `;
 
-  formChecker.addEventListener("click", () => {
-    const isFullFilled = InputValidator.validateFullFilled(input);
-    if (!isFullFilled) return;
+  EventDispatcher.register({
+    eventType: "click",
+    selector: "form-checker",
+    handler: () => {
+      console.log(input);
+      const isFullFilled = InputValidator.validateFullFilled(input);
+      if (!isFullFilled) return;
 
-    const isFullCorrectType = InputValidator.validateFullCorrectType(input);
-    if (isFullCorrectType) {
-      console.log("ok");
-    } else {
-      console.log("no");
-    }
-    console.log(input);
+      const isFullCorrectType = InputValidator.validateFullCorrectType(input);
+      if (isFullCorrectType) {
+        console.log("ok");
+      } else {
+        console.log("no");
+      }
+    },
   });
-  // EventDispatcher.register({
-  //   eventType: "click",
-  //   selector: "form-checker",
-  //   handler: () => {
-  //     console.log(input);
-  //     const isFullFilled = InputValidator.validateFullFilled(input);
-  //     if (!isFullFilled) return;
-
-  //     const isFullCorrectType = InputValidator.validateFullCorrectType(input);
-  //     if (isFullCorrectType) {
-  //       console.log("ok");
-  //     } else {
-  //       console.log("no");
-  //     }
-  //   },
-  // });
   return formChecker;
 };

--- a/src/components/form/MoneyForm.js
+++ b/src/components/form/MoneyForm.js
@@ -1,3 +1,4 @@
+import { EventDispatcher } from "../../store/EventBusStore.js";
 import { ElementManager } from "../../utils/ElementManager.js";
 import { NumberManager } from "../../utils/NumberManager.js";
 
@@ -13,17 +14,26 @@ export const MoneyForm = (input) => {
     `;
 
   const moneyTypeImg = moneyForm.querySelector(".money-input-wrapper > img");
-  moneyTypeImg.addEventListener("click", (e) => {
-    input.moneyType = input.moneyType === "income" ? "expense" : "income";
-    moneyTypeImg.src = `./src/assets/${input.moneyType}.png`;
-    moneyTypeImg.alt = `${input.moneyType} icon`;
+  EventDispatcher.register({
+    eventType: "click",
+    selector: "money-input-wrapper > img",
+    handler: () => {
+      input.moneyType = input.moneyType === "income" ? "expense" : "income";
+      moneyTypeImg.src = `./src/assets/${input.moneyType}.png`;
+      moneyTypeImg.alt = `${input.moneyType} icon`;
+    },
   });
-
-  moneyForm.addEventListener("input", (e) => {
-    const moneyInput = moneyForm.querySelector(".money-input-wrapper > input");
-    const normalMoney = NumberManager.parseToNormalNumber(e.target.value);
-    moneyInput.value = NumberManager.parseToCommaNumber(normalMoney);
-    input.money = normalMoney;
+  EventDispatcher.register({
+    eventType: "input",
+    selector: "form-money",
+    handler: (e) => {
+      const moneyInput = moneyForm.querySelector(
+        ".money-input-wrapper > input"
+      );
+      const normalMoney = NumberManager.parseToNormalNumber(e.target.value);
+      moneyInput.value = NumberManager.parseToCommaNumber(normalMoney);
+      input.money = normalMoney;
+    },
   });
   return moneyForm;
 };

--- a/src/components/form/PaymentForm.js
+++ b/src/components/form/PaymentForm.js
@@ -1,3 +1,4 @@
+import { EventDispatcher } from "../../store/EventBusStore.js";
 import { ElementManager } from "../../utils/ElementManager.js";
 import { Modal } from "../modal/index.js";
 import { DropDown } from "./DropDown.js";
@@ -15,52 +16,55 @@ export const PaymentForm = (input) => {
   `;
 
   const paymentImg = paymentForm.querySelector("#payment > img");
-  paymentForm.addEventListener("click", (e) => {
-    // 값 선택 업데이트+화면에 표시
-    if (e.target.closest(".drop-down-li")) {
-      const selectedPayment = e.target.innerText;
-      input.payment = selectedPayment;
-      const paymentTextInput = paymentForm.querySelector("#payment > span");
-      paymentTextInput.textContent = selectedPayment;
+  EventDispatcher.register({
+    eventType: "click",
+    selector: "form-payment",
+    handler: (e) => {
+      // 값 선택 업데이트+화면에 표시
+      if (e.target.closest(".drop-down-li")) {
+        const selectedPayment = e.target.innerText;
+        input.payment = selectedPayment;
+        const paymentTextInput = paymentForm.querySelector("#payment > span");
+        paymentTextInput.textContent = selectedPayment;
 
-      const event = new Event("input", {
-        bubbles: true, // 이벤트 버블링을 허용 -> entireForm까지 도달
-        cancelable: false,
-      });
-      paymentTextInput.dispatchEvent(event);
-    }
+        const event = new Event("input", {
+          bubbles: true, // 이벤트 버블링을 허용 -> entireForm까지 도달
+          cancelable: false,
+        });
+        paymentTextInput.dispatchEvent(event);
+      }
 
-    // 값 추가
-    if (e.target.closest(".add-button")) {
-      Modal.renderModal("add", (newPayment) => {
-        defaultPayment.push(newPayment);
-      });
-    }
+      // 값 추가
+      if (e.target.closest(".add-button")) {
+        Modal.renderModal("add", (newPayment) => {
+          defaultPayment.push(newPayment);
+        });
+      }
 
-    // 값 삭제
-    if (e.target.closest(".delete-button")) {
-      Modal.renderModal("delete", (isConfirm) => {
-        const selectedLi = e.target.closest("li");
-        const selectedSpan = selectedLi.querySelector(".drop-down-li");
-        defaultPayment = defaultPayment.filter(
-          (item) => item !== selectedSpan.textContent
-        );
-      });
-    }
+      // 값 삭제
+      if (e.target.closest(".delete-button")) {
+        Modal.renderModal("delete", (isConfirm) => {
+          const selectedLi = e.target.closest("li");
+          const selectedSpan = selectedLi.querySelector(".drop-down-li");
+          defaultPayment = defaultPayment.filter(
+            (item) => item !== selectedSpan.textContent
+          );
+        });
+      }
 
-    // 이미지 업데이트
-    isPaymentOpen = !isPaymentOpen;
-    paymentImg.src = `./src/assets/chevron-${
-      isPaymentOpen ? "up" : "down"
-    }.png`;
-    // 드롭다운 화면에 표시/제거
-    if (isPaymentOpen) {
-      paymentForm.appendChild(DropDown("payment", defaultPayment));
-    } else {
-      const dropDown = paymentForm.querySelector(".drop-down");
-      paymentForm.removeChild(dropDown);
-    }
+      // 이미지 업데이트
+      isPaymentOpen = !isPaymentOpen;
+      paymentImg.src = `./src/assets/chevron-${
+        isPaymentOpen ? "up" : "down"
+      }.png`;
+      // 드롭다운 화면에 표시/제거
+      if (isPaymentOpen) {
+        paymentForm.appendChild(DropDown("payment", defaultPayment));
+      } else {
+        const dropDown = paymentForm.querySelector(".drop-down");
+        paymentForm.removeChild(dropDown);
+      }
+    },
   });
-
   return paymentForm;
 };

--- a/src/components/form/PaymentForm.js
+++ b/src/components/form/PaymentForm.js
@@ -59,7 +59,9 @@ export const PaymentForm = (input) => {
       }.png`;
       // 드롭다운 화면에 표시/제거
       if (isPaymentOpen) {
-        paymentForm.appendChild(DropDown("payment", defaultPayment));
+        paymentForm.appendChild(
+          DropDown({ type: "payment", data: defaultPayment })
+        );
       } else {
         const dropDown = paymentForm.querySelector(".drop-down");
         paymentForm.removeChild(dropDown);

--- a/src/components/form/PaymentForm.js
+++ b/src/components/form/PaymentForm.js
@@ -19,19 +19,18 @@ export const PaymentForm = (input) => {
   EventDispatcher.register({
     eventType: "click",
     selector: "form-payment",
-    handler: (e) => {
+    handler: ({ target }) => {
       // 값 선택 업데이트+화면에 표시
-      console.log(e.target);
-      const dropDownLi = e.target.closest(".drop-down-li");
+      const dropDownLi = target.closest(".drop-down-li");
       if (dropDownLi) {
-        const selectedPayment = e.target.innerText;
+        const selectedPayment = target.innerText;
         input.payment = selectedPayment;
         const paymentTextInput = paymentForm.querySelector("#payment > span");
         paymentTextInput.textContent = selectedPayment;
       }
 
       // 값 추가
-      const addButton = e.target.closest(".add-button");
+      const addButton = target.closest(".add-button");
       if (addButton) {
         Modal.renderModal("add", (newPayment) => {
           defaultPayment.push(newPayment);
@@ -39,10 +38,10 @@ export const PaymentForm = (input) => {
       }
 
       // 값 삭제
-      const deleteButton = e.target.closest(".delete-button");
+      const deleteButton = target.closest(".delete-button");
       if (deleteButton) {
         Modal.renderModal("delete", (isConfirm) => {
-          const selectedLi = e.target.closest("li");
+          const selectedLi = target.closest("li");
           const selectedSpan = selectedLi.querySelector(".drop-down-li");
           defaultPayment = defaultPayment.filter(
             (item) => item !== selectedSpan.textContent

--- a/src/components/form/PaymentForm.js
+++ b/src/components/form/PaymentForm.js
@@ -21,28 +21,26 @@ export const PaymentForm = (input) => {
     selector: "form-payment",
     handler: (e) => {
       // 값 선택 업데이트+화면에 표시
-      if (e.target.closest(".drop-down-li")) {
+      console.log(e.target);
+      const dropDownLi = e.target.closest(".drop-down-li");
+      if (dropDownLi) {
         const selectedPayment = e.target.innerText;
         input.payment = selectedPayment;
         const paymentTextInput = paymentForm.querySelector("#payment > span");
         paymentTextInput.textContent = selectedPayment;
-
-        const event = new Event("input", {
-          bubbles: true, // 이벤트 버블링을 허용 -> entireForm까지 도달
-          cancelable: false,
-        });
-        paymentTextInput.dispatchEvent(event);
       }
 
       // 값 추가
-      if (e.target.closest(".add-button")) {
+      const addButton = e.target.closest(".add-button");
+      if (addButton) {
         Modal.renderModal("add", (newPayment) => {
           defaultPayment.push(newPayment);
         });
       }
 
       // 값 삭제
-      if (e.target.closest(".delete-button")) {
+      const deleteButton = e.target.closest(".delete-button");
+      if (deleteButton) {
         Modal.renderModal("delete", (isConfirm) => {
           const selectedLi = e.target.closest("li");
           const selectedSpan = selectedLi.querySelector(".drop-down-li");

--- a/src/components/form/index.js
+++ b/src/components/form/index.js
@@ -6,6 +6,7 @@ import { CategoryForm } from "./CategoryForm.js";
 import { FormChecker } from "./FormChecker.js";
 import { ElementManager } from "../../utils/ElementManager.js";
 import { InputValidator } from "../../utils/InputValidator.js";
+import { EventDispatcher } from "../../store/EventBusStore.js";
 
 export const EntireForm = () => {
   const entireForm = ElementManager.renderElement("div", "entire-form");
@@ -30,17 +31,20 @@ export const EntireForm = () => {
   });
   entireForm.appendChild(FormChecker(input));
 
-  entireForm.addEventListener("input", () => {
-    const isFullFilled = InputValidator.validateFullFilled(input);
-    const formCheckerWrapper = entireForm.querySelector(
-      ".form-checker > .img-wrapper"
-    );
-    if (isFullFilled) {
-      formCheckerWrapper.classList.add("active");
-    } else {
-      formCheckerWrapper.classList.remove("active");
-    }
+  EventDispatcher.register({
+    eventType: "input",
+    selector: "entire-form",
+    handler: () => {
+      const isFullFilled = InputValidator.validateFullFilled(input);
+      const formCheckerWrapper = entireForm.querySelector(
+        ".form-checker > .img-wrapper"
+      );
+      if (isFullFilled) {
+        formCheckerWrapper.classList.add("active");
+      } else {
+        formCheckerWrapper.classList.remove("active");
+      }
+    },
   });
-
   return entireForm;
 };

--- a/src/components/form/index.js
+++ b/src/components/form/index.js
@@ -32,9 +32,13 @@ export const EntireForm = () => {
 
   entireForm.addEventListener("input", () => {
     const isFullFilled = InputValidator.validateFullFilled(input);
+    const formCheckerWrapper = entireForm.querySelector(
+      ".form-checker > .img-wrapper"
+    );
     if (isFullFilled) {
-      const formChecker = entireForm.querySelector(".form-checker");
-      formChecker.classList.add("active");
+      formCheckerWrapper.classList.add("active");
+    } else {
+      formCheckerWrapper.classList.remove("active");
     }
   });
 

--- a/src/components/list/DateList.js
+++ b/src/components/list/DateList.js
@@ -1,14 +1,17 @@
 import { DateManager } from "../../utils/DateManager.js";
 import { ElementManager } from "../../utils/ElementManager.js";
+import { NumberManager } from "../../utils/NumberManager.js";
 import { ListItem } from "./ListItem.js";
 
-export const DateList = (date, list) => {
+export const DateList = (date, data) => {
   const splitDate = date.split("-");
   const dateList = ElementManager.renderElement("div", "list-date");
   const dateOverview = ElementManager.renderElement("div", [
     "date-overview",
     "serif-14",
   ]);
+
+  const totalMoney = NumberManager.calculateTotalMoney(data);
   dateOverview.innerHTML = `
   <div class="date">
     <span>${splitDate[1]}월 ${splitDate[2]}일</span>
@@ -17,18 +20,18 @@ export const DateList = (date, list) => {
   <div class="money-counter">
     <div>
         <span>수입</span>
-        <span>0원</span>
+        <span>${NumberManager.parseToCommaNumber(totalMoney.income)}원</span>
     </div>
     <div>
         <span>지출</span>
-        <span>0원</span>
+        <span>${NumberManager.parseToCommaNumber(totalMoney.expense)}원</span>
     </div>
   </div>
   `;
   dateList.appendChild(dateOverview);
 
   const dateWrapper = ElementManager.renderElement("div", "date-wrapper");
-  list.map((input) => {
+  data.map((input) => {
     dateWrapper.appendChild(ListItem(input));
   });
   dateList.appendChild(dateWrapper);

--- a/src/components/list/ListItem.js
+++ b/src/components/list/ListItem.js
@@ -1,7 +1,9 @@
+import { EventDispatcher } from "../../store/EventBusStore.js";
 import { ElementManager } from "../../utils/ElementManager.js";
 
 export const ListItem = (item) => {
   const listItem = ElementManager.renderElement("div", "list-item");
+  listItem.dataset.uid = item.uid;
   listItem.innerHTML = `
   <span class="category light-12">${item.category}</span>
   <span class="content">${item.content}</span>
@@ -16,5 +18,14 @@ export const ListItem = (item) => {
     <span class="semibold-12">삭제</span>
   </button>
   `;
+
+  EventDispatcher.register({
+    eventType: "click",
+    selector: "delete-button",
+    handler: (e) => {
+      const listItem = e.target.closest(".list-item");
+      const uid = listItem.dataset.uid;
+    },
+  });
   return listItem;
 };

--- a/src/components/list/ListItem.js
+++ b/src/components/list/ListItem.js
@@ -9,7 +9,12 @@ export const ListItem = (item) => {
   <span class="money">${item.moneyType === "expense" ? "-" : ""}${
     item.money
   }원</span>
-  </div>
+  <button class="delete-button">
+    <div class="img-wrapper">
+      <img width="8px" height="8px" src="./src/assets/closed_white.svg" alt="closed icon"/>
+    </div>
+    <span class="semibold-12">삭제</span>
+  </button>
   `;
   return listItem;
 };

--- a/src/components/list/ListTypeFilter.js
+++ b/src/components/list/ListTypeFilter.js
@@ -26,7 +26,6 @@ export const ListTypeFilter = (
     handler: () => {
       // 필터링 화면 업데이트
       let isActive = false;
-      console.log(type);
       if (type === "income") {
         entireFilter.isIncomeTypeOpen = !entireFilter.isIncomeTypeOpen;
         isActive = entireFilter.isIncomeTypeOpen;

--- a/src/components/list/ListTypeFilter.js
+++ b/src/components/list/ListTypeFilter.js
@@ -1,3 +1,4 @@
+import { EventDispatcher } from "../../store/EventBusStore.js";
 import { ElementManager } from "../../utils/ElementManager.js";
 import { ListFilter } from "../../utils/ListFilter.js";
 import { NumberManager } from "../../utils/NumberManager.js";
@@ -9,42 +10,51 @@ export const ListTypeFilter = (
   entireFilter,
   renderListWrapper
 ) => {
-  const listTypeFilter = ElementManager.renderElement("div", "list-type");
+  const listTypeFilter = ElementManager.renderElement(
+    "div",
+    `list-type-${type}`
+  );
   listTypeFilter.innerHTML = `
   <img src="./src/assets/checkbox.png" alt="checkbox"/>
   <span>${type === "income" ? "수입" : "지출"}</span>
   <span>${NumberManager.parseToCommaNumber(totalMoney)}</span>
   `;
 
-  listTypeFilter.addEventListener("click", () => {
-    // 필터링 화면 업데이트
-    let isActive = false;
-    if (type === "income") {
-      entireFilter.isIncomeTypeOpen = !entireFilter.isIncomeTypeOpen;
-      isActive = entireFilter.isIncomeTypeOpen;
-    } else {
-      entireFilter.isExpenseTypeOpen = !entireFilter.isExpenseTypeOpen;
-      isActive = entireFilter.isExpenseTypeOpen;
-    }
-    const listTypeFilterImg = listTypeFilter.querySelector("img");
-    listTypeFilterImg.src = `./src/assets/${
-      isActive ? "checkbox" : "uncheckbox"
-    }.png`;
+  EventDispatcher.register({
+    eventType: "click",
+    selector: `list-type-${type}`,
+    handler: () => {
+      // 필터링 화면 업데이트
+      let isActive = false;
+      console.log(type);
+      if (type === "income") {
+        entireFilter.isIncomeTypeOpen = !entireFilter.isIncomeTypeOpen;
+        isActive = entireFilter.isIncomeTypeOpen;
+      } else {
+        entireFilter.isExpenseTypeOpen = !entireFilter.isExpenseTypeOpen;
+        isActive = entireFilter.isExpenseTypeOpen;
+      }
+      const listTypeFilterImg = listTypeFilter.querySelector("img");
+      listTypeFilterImg.src = `./src/assets/${
+        isActive ? "checkbox" : "uncheckbox"
+      }.png`;
 
-    // 내역 데이터 업데이트
-    const updatedTransactioin = ListFilter.groupTransactionsByMoneyType(
-      groupedListByMonth,
-      entireFilter
-    );
+      // 내역 데이터 업데이트
+      const updatedTransactioin = ListFilter.groupTransactionsByMoneyType(
+        groupedListByMonth,
+        entireFilter
+      );
 
-    // 내역 개요 화면 업데이트
-    const listOverviewCounter = document.querySelector(
-      ".list-overview > .list-counter > .total-count"
-    );
-    listOverviewCounter.textContent = updatedTransactioin.length + "건";
+      // 내역 개요 화면 업데이트
+      const listOverviewCounter = document.querySelector(
+        ".list-overview > .list-counter > .total-count"
+      );
+      listOverviewCounter.textContent = updatedTransactioin.length + "건";
 
-    // 내역 화면 업데이트
-    renderListWrapper(updatedTransactioin);
+      // 내역 화면 업데이트
+      renderListWrapper(updatedTransactioin);
+    },
   });
+
   return listTypeFilter;
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,12 @@
 import { createLayout } from "./pages/Layout.js";
+import { EventDispatcher } from "./store/EventBusStore.js";
 import { Router } from "./utils/router.js";
 
 document.addEventListener("DOMContentLoaded", () => {
   try {
     createLayout();
     Router.setupRouter();
+    document.addEventListener("click", (e) => EventDispatcher.dispatch(e));
   } catch (error) {
     console.error("Error setting up layout:", error);
   }

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ document.addEventListener("DOMContentLoaded", () => {
     createLayout();
     Router.setupRouter();
     document.addEventListener("click", (e) => EventDispatcher.dispatch(e));
+    document.addEventListener("input", (e) => EventDispatcher.dispatch(e));
   } catch (error) {
     console.error("Error setting up layout:", error);
   }

--- a/src/store/EventBusStore.js
+++ b/src/store/EventBusStore.js
@@ -1,0 +1,24 @@
+export const EventDispatcher = {
+  handlers: {
+    click: {},
+    input: {},
+  },
+
+  register({ eventType, selector, handler }) {
+    this.handlers[eventType][selector] = handler;
+  },
+
+  dispatch(e) {
+    const eventType = e.type;
+    console.log(eventType);
+    const fitHandlers = this.handlers[eventType];
+    console.log(fitHandlers);
+    for (const key in fitHandlers) {
+      const matchedEl = e.target.closest(`.${key}`);
+      if (matchedEl) {
+        this.handlers[eventType][key](e);
+        break;
+      }
+    }
+  },
+};

--- a/src/store/EventBusStore.js
+++ b/src/store/EventBusStore.js
@@ -10,9 +10,7 @@ export const EventDispatcher = {
 
   dispatch(e) {
     const eventType = e.type;
-    console.log(eventType);
     const fitHandlers = this.handlers[eventType];
-    console.log(fitHandlers);
     for (const key in fitHandlers) {
       const matchedEl = e.target.closest(`.${key}`);
       if (matchedEl) {

--- a/src/store/ListStore.js
+++ b/src/store/ListStore.js
@@ -1,0 +1,5 @@
+export class ListStore {
+  constructor() {
+    this.data = [];
+  }
+}

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -9,11 +9,10 @@
   background-color: var(--nuetral-surface-default);
   display: flex;
   flex-direction: row;
-  justify-content: space-between;
   align-items: center;
   width: 894px;
   height: 76px;
-  padding: 16px 24px;
+  padding: 16px 0;
   margin: 0 auto;
   border-style: solid;
   border-width: 0.5px;
@@ -21,20 +20,13 @@
 }
 
 .entire-form > div {
+  box-sizing: content-box;
   position: relative;
   display: flex;
+  padding: 0 24px;
+  height: 44px;
   flex-direction: column;
-}
-
-.entire-form > div:not(:nth-last-child(1)):not(:nth-last-child(2))::after {
-  content: "";
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  right: -24px;
-  width: 24px;
   border-right: 0.5px solid var(--nuetral-border-default);
-  background-color: transparent;
 }
 
 .entire-form > div:last-child {
@@ -89,7 +81,7 @@ input#money {
 .form-content > div {
   position: absolute;
   top: 0;
-  right: 0;
+  right: 24px;
   color: var(--nuetral-text-weak);
 }
 
@@ -116,8 +108,8 @@ button#payment {
 .drop-down {
   position: absolute;
   top: calc(100% + 16px);
-  left: -23.78px;
-  width: calc(100% + 23.78 * 2px);
+  left: 0;
+  width: 100%;
   border-style: solid;
   border-width: 0.5px;
   border-color: var(--nuetral-border-default);
@@ -141,29 +133,25 @@ button#payment {
 }
 
 .form-checker {
-  position: relative;
   width: 40px;
   height: 40px;
-  border-radius: 50%;
   display: flex;
   justify-content: center;
   align-items: center;
-  overflow: hidden;
 }
 
-.form-checker::before {
-  content: "";
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
+.form-checker > .img-wrapper {
+  width: 40px;
+  height: 40px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 50%;
+  background-color: rgba(0, 0, 0, 0.32);
+}
+
+.form-checker > .img-wrapper.active {
   background-color: var(--nuetral-text-default);
-  opacity: 0.32;
-}
-
-.form-checker.active::before {
-  opacity: 1;
 }
 
 .form-checker > img {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -268,3 +268,29 @@ button#payment {
   flex-grow: 1;
   text-align: right;
 }
+
+.list-item .delete-button {
+  display: none;
+}
+
+.list-item:hover .delete-button {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 4px;
+  padding: 0;
+}
+
+.list-item .delete-button .img-wrapper {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: var(--danger-surface-default);
+}
+
+.list-item .delete-button span {
+  color: var(--danger-text-default);
+}

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -121,6 +121,7 @@ button#payment {
   justify-content: space-between;
   align-items: center;
   padding: 16px 24px;
+  background-color: var(--nuetral-surface-default);
 }
 
 .drop-down > li:not(:last-child) {

--- a/src/utils/ListFilter.js
+++ b/src/utils/ListFilter.js
@@ -2,7 +2,11 @@ export const ListFilter = {
   groupTransactionsByMonth: (transactions, month) => {
     return transactions
       .filter((transaction) => transaction.date.getMonth() + 1 === month)
-      .sort((a, b) => b.date - a.date);
+      .sort((a, b) => b.date - a.date)
+      .map((item, index) => ({
+        ...item,
+        uid: `uid-${item.date.getTime()}-${index}`,
+      }));
   },
   groupTransactionsByDate: (transactions) => {
     const groupedListByDate = {};


### PR DESCRIPTION
## 😎 작업 완료 화면
<img width="1840" height="1191" alt="image" src="https://github.com/user-attachments/assets/0170aa08-8bfa-42b3-a5fd-18506273a984" />

## ✅ 완료 작업 목록
### 공통 기능
- 전역 이벤트 관리자 구현
### 내역 입력
- 드롭다운 부분 css에서 영역 벗어나는 것 수정
### 수입지출 목록
- 수입지출 개별 목록 호버시 삭제 버튼 나타나도록 구현
- 달별로 수입지출 목록 불러올 때, 데이터에 uid 삽입
- 수입지출 목록 제공하는 방법 store로 변경하는 것 고민

## 🤔 주요 고민과 해결 과정
### 🔎 이벤트 처리 로직 분리를 위한 전역 이벤트 디스패처 도입
```
이벤트 처리 로직을 view와 분리하여, 한 곳에 모아두는 방법을 구현하기 위해
-> 전역 이벤트 위임 방식을 선택했습니다.
```
#### 리액트 VS VanillaJS
- 리액트의 처리 방식: 합성 이벤트 시스템 구축 → 일관된 이벤트 동작 보장
- vanillaJS의 처리 방식: 최상위 dom에서 이벤트 하나 등록
  - html/js 코드에서 이벤트 바인딩 의도 명확히 드러내기
  - 이벤트 로직은 하나의 모듈에 모아두기
  - document.body에서 위임 처리하기

#### 전역 이벤트 처리 버스 구현 방법
- 종류
  - Observer 패턴
  - Pub/Sub 패턴
  - 이벤트 위임을 적용한 커스텀 전역 디스패처 ✅
- 선택 이유: 전역에 포인트를 둔 이벤트 처리 방식이기에 → 변경이 발생했을 때 모든 구독자에게 알림이 가는 구조가 비효율적이라고 생각했습니다.

#### 전역 이벤트 디스패처 구조
```
export const EventDispatcher = {
  handlers: {
    click: {},
    input: {},
  },
  register({ eventType, selector, handler }) {
    this.handlers[eventType][selector] = handler;
  },
  dispatch(e) { (생략) },
};
```

#### 트러블슈팅
- 고민: 이벤트 등록은 파라미터로 해서 유니크하게 저장이 가능한데, 이벤트 실행은 이벤트 자체로 판단해야 한다. 이때, 해당 이벤트가 어떠한 것과 관련된 이벤트인지 구별할 수 있는 방법이 있는가?
- 방법
  - register: selector에 유효한 최상단 className 전달 → className을 key, handler(실행 함수)를 value로 할당
  - dispatch: handlers에 저장된 객체의 key들 모두 순회하며 → 관련 이벤트 찾기
    - 효율성을 위해 handlers의 구조를 단순 object에서 →  event type을 key로 1차 필터링 진행
    - event type은 dispatch의 파라미터 이벤트로 바로 전달되어 식별되기에 필터링에 사용 가능
    - event type(click, input)에 따라 걸러진 해당 타입에 대한 등록된 이벤트 전체 순회
