### PR TITLE
[유재민] - store에 observer 추가 / 삭제 기능 구현 / 수정 모드 진입

### DIFF
--- a/api/recordsApi.js
+++ b/api/recordsApi.js
@@ -25,7 +25,7 @@ export function fetchRecords() {
 //
 export function addRecordsToServer({ date, recordId, item }) {
   const records = store.getRecords();
-  const found = records.find((record) => record.date === date);
+  const found = records.find((record) => record.date.toString() === date.toString());
 
   if (found) {
     return fetch(`${BASE_URL}/${found.id}`, {
@@ -42,6 +42,32 @@ export function addRecordsToServer({ date, recordId, item }) {
         date,
         items: [item],
       }),
+    });
+  }
+}
+
+export function deleteRecordsFromServer(dateId, itemId) {
+  // store에서 해당 날짜의 record를 가져옴
+  const record = store.getRecords().find((record) => record.id.toString() === dateId.toString());
+
+  if (!record) return;
+
+  // 삭제하고자 하는 데이터를 제외한 items[]
+  const updatedItems = record.items.filter((item) => {
+    return item.id.toString() !== itemId.toString();
+  });
+
+  if (updatedItems.length === 0) {
+    // 해당 날짜 객체 자체를 삭제
+    return fetch(`${BASE_URL}/${dateId}`, {
+      method: "DELETE",
+    });
+  } else {
+    // 아이템만 삭제하고 나머지는 유지
+    return fetch(`${BASE_URL}/${dateId}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ items: updatedItems }),
     });
   }
 }

--- a/assets/main.css
+++ b/assets/main.css
@@ -177,13 +177,7 @@
   justify-content: center;
 }
 
-/* .record-item:hover {
-  opacity: 0.7;
-} */
-.record-item:hover .delete {
-  display: flex;
-}
-.record-item > div {
+.record-item > div:not(.delete) {
   display: flex;
   margin-right: 16px;
 }
@@ -254,13 +248,20 @@
 .record-item .category.용돈 {
   background-color: var(--colorchip-40);
 }
-
+.record-item:hover .delete {
+  display: flex;
+}
+.record-item:hover {
+  background-color: var(--neutral-surface-point);
+}
 .delete {
   gap: 8px;
   display: none;
   align-items: center;
   justify-content: center;
+  cursor: pointer;
 }
+
 .delete-button-wrapper {
   background: var(--danger-surface-default);
   border-radius: 20px;

--- a/assets/main.css
+++ b/assets/main.css
@@ -262,6 +262,13 @@
   cursor: pointer;
 }
 
+.record-item.selected {
+  background-color: var(--neutral-surface-point);
+}
+.record-item.selected .delete {
+  display: flex;
+}
+
 .delete-button-wrapper {
   background: var(--danger-surface-default);
   border-radius: 20px;

--- a/assets/main.css
+++ b/assets/main.css
@@ -122,10 +122,12 @@
   margin-right: 8px;
 }
 .total-income {
+  display: flex;
   margin-left: auto;
   margin-right: 12px;
 }
 .total-outcome {
+  display: flex;
   margin-right: 0;
 }
 .record-header {
@@ -145,13 +147,28 @@
   border-bottom: 0.5px solid var(--neutral-border-default);
 }
 
-.records-container > button {
+.total-amount > button {
   overflow: hidden;
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 16px;
-  height: 16px;
+  width: 13px;
+  height: 13px;
+  border-radius: 50%;
+}
+
+.income-filter > img {
+  width: 14px;
+  height: 14px;
+
+  object-fit: cover;
+}
+
+.outcome-filter > img {
+  width: 14px;
+  height: 14px;
+
+  object-fit: cover;
 }
 .record-item {
   display: flex;
@@ -160,6 +177,12 @@
   justify-content: center;
 }
 
+/* .record-item:hover {
+  opacity: 0.7;
+} */
+.record-item:hover .delete {
+  display: flex;
+}
 .record-item > div {
   display: flex;
   margin-right: 16px;
@@ -218,4 +241,38 @@
 
 .record-item .category.미분류 {
   background-color: var(--pastel-lavenderPink);
+}
+
+.record-item .category.월급 {
+  background-color: var(--colorchip-20);
+}
+
+.record-item .category.기타수입 {
+  background-color: var(--colorchip-10);
+}
+
+.record-item .category.용돈 {
+  background-color: var(--colorchip-40);
+}
+
+.delete {
+  gap: 8px;
+  display: none;
+  align-items: center;
+  justify-content: center;
+}
+.delete-button-wrapper {
+  background: var(--danger-surface-default);
+  border-radius: 20px;
+  width: 16px;
+  height: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.delete-icon {
+  width: 12px;
+  height: 12px;
+  filter: brightness(0) invert(1);
 }

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -153,7 +153,7 @@ a {
 
 @font-face {
   font-family: "ChosunMyeongjo";
-  src: url("./fonts/ChosunNm.ttf") format("truetype");
+  src: url("./fonts/ChosunNm.woff") format("truetype");
   font-weight: normal;
   font-style: normal;
 }

--- a/components/header.html
+++ b/components/header.html
@@ -6,9 +6,9 @@
         <img src="../assets/icons/chevron-left.svg" alt="Previous Month" />
       </button>
       <div class="date-display">
-        <div class="year">2025</div>
+        <div class="font-light-14 year">2025</div>
         <div class="month">7</div>
-        <div class="month-en">July</div>
+        <div class="font-light-14 month-en">July</div>
       </div>
       <button class="next-month">
         <img src="../assets/icons/chevron-right.svg" alt="Next Month" />

--- a/scripts/header.js
+++ b/scripts/header.js
@@ -1,6 +1,7 @@
 import { renderRecordHeader, renderRecords } from "./records.js";
 import { elements } from "./elements.js";
 import { store } from "./store.js";
+
 export async function loadHeaderHTML() {
   const headerEl = elements.headerEl();
   const res = await fetch("./components/header.html");
@@ -9,16 +10,42 @@ export async function loadHeaderHTML() {
 }
 
 export function initializeHeader() {
-  const headerEl = document.querySelector("header");
+  const headerEl = elements.headerEl();
 
   const prevBtn = headerEl.querySelector(".prev-month");
   const nextBtn = headerEl.querySelector(".next-month");
+
+  prevBtn.addEventListener("click", () => {
+    const { year, month } = store.getDate();
+
+    if (month === 1) {
+      store.setDate(year - 1, 12);
+    } else {
+      store.setDate(year, month - 1);
+    }
+  });
+
+  nextBtn.addEventListener("click", () => {
+    const { year, month } = store.getDate();
+
+    if (month === 12) {
+      store.setDate(year + 1, 1);
+    } else {
+      store.setDate(year, month + 1);
+    }
+  });
+
+  // 초기 렌더링
+  const { year, month } = store.getDate();
+  updateHeaderDateUI(year, month);
+}
+
+export function updateHeaderDateUI(year, month) {
+  const headerEl = elements.headerEl();
   const yearEl = headerEl.querySelector(".year");
   const monthEl = headerEl.querySelector(".month");
   const monthEnEl = headerEl.querySelector(".month-en");
 
-  let currentYear = yearEl.textContent;
-  let currentMonth = monthEl.textContent;
   const monthNames = [
     "",
     "January",
@@ -35,35 +62,7 @@ export function initializeHeader() {
     "December",
   ];
 
-  function updateDisplay() {
-    yearEl.textContent = currentYear;
-    monthEl.textContent = currentMonth;
-    monthEnEl.textContent = monthNames[currentMonth];
-  }
-
-  prevBtn.addEventListener("click", () => {
-    if (currentMonth === 1) {
-      currentMonth = 12;
-      currentYear--;
-    } else {
-      currentMonth--;
-    }
-
-    updateDisplay();
-    renderRecordHeader(currentYear, currentMonth, store.getRecords());
-    renderRecords(currentYear, currentMonth, store.getRecords());
-  });
-
-  nextBtn.addEventListener("click", () => {
-    if (currentMonth === 12) {
-      currentMonth = 1;
-      currentYear++;
-    } else {
-      currentMonth++;
-    }
-
-    updateDisplay();
-    renderRecordHeader(currentYear, currentMonth, store.getRecords());
-    renderRecords(currentYear, currentMonth, store.getRecords());
-  });
+  yearEl.textContent = year;
+  monthEl.textContent = month;
+  monthEnEl.textContent = monthNames[month];
 }

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -7,6 +7,7 @@ import {
   initPaymentDropdown,
   initCategoryDropdown,
   initInputChanges,
+  initModifyEvent,
 } from "./input.js";
 import {
   renderRecords,
@@ -39,6 +40,7 @@ window.addEventListener("DOMContentLoaded", async () => {
   subscribeStore();
   renderRecordHeader(year, month, store.getRecords());
   renderRecords(year, month, store.getRecords());
+  initModifyEvent();
   initDeleteEvent();
 });
 window.addEventListener("hashchange", loadPage);

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -14,7 +14,9 @@ import {
   getFormattedDate,
   initVisibleButton,
   renderRecordHeader,
+  initDeleteEvent,
 } from "./records.js";
+import { subscribeStore } from "./subscribe.js";
 window.addEventListener("DOMContentLoaded", async () => {
   // 오늘 날짜 기준 연도와 월 추출
   const today = new Date();
@@ -34,7 +36,9 @@ window.addEventListener("DOMContentLoaded", async () => {
   getInputValues();
 
   await store.init();
+  subscribeStore();
   renderRecordHeader(year, month, store.getRecords());
   renderRecords(year, month, store.getRecords());
+  initDeleteEvent();
 });
 window.addEventListener("hashchange", loadPage);

--- a/scripts/input.js
+++ b/scripts/input.js
@@ -1,7 +1,7 @@
 // input 바에서 사용하는 드롭다운, 유효성 검증, 글자수 세기 등의 로직을 다루는 파일
 import { addRecordsToServer } from "../api/recordsApi.js";
+import { store } from "./store.js";
 import { elements } from "./elements.js";
-import { addRecord } from "./records.js";
 
 let valueSign = "minus"; // or "plus"
 let paymentOptions = ["현금", "신용카드", "추가하기"];
@@ -180,10 +180,10 @@ export const getInputValues = () => {
         amount,
       },
     };
-    // API 호출
-    addRecordsToServer(formInput);
 
-    // 로컬 store와 화면 렌더링
-    addRecord(formInput);
+    // 로컬 store에 추가
+    addRecordsToServer(formInput).then(() => {
+      store.addRecordToStore(formInput);
+    });
   });
 };

--- a/scripts/records.js
+++ b/scripts/records.js
@@ -1,4 +1,5 @@
 // 입력받은 정보를 토대로 삽입 / 수정 / 삭제 기능을 담당하는 함수들을 다루는 파일
+import { deleteRecordsFromServer } from "../api/recordsApi.js";
 import { elements } from "./elements.js";
 import { store } from "./store.js";
 
@@ -164,23 +165,6 @@ export const getTotalAmount = (items) => {
   return { income, outcome };
 };
 
-export const addRecord = ({ recordId, date, item }) => {
-  // record에 추가하려는 날짜에 대한 정보가 이미 있나 확인
-  const foundRecord = store.getRecords().find((record) => record.date === date);
-
-  if (foundRecord) {
-    // 이미 있는 날짜라면 해당 날짜의 items 배열에 추가
-    foundRecord.items.push(item);
-  } else {
-    // 없는 날짜라면 record에 날짜 포함한 새 객체 생성
-    store.addRecordToStore({
-      id: recordId,
-      date,
-      items: [item],
-    });
-  }
-};
-
 // 전체 내역 수입 지출 필터링
 const toggleRecordVisibility = (type) => {
   // type = "income" | "outcome"
@@ -248,6 +232,8 @@ export function initDeleteEvent() {
     const dateId = e.target.closest(".record-container").getAttribute("date-id");
     const itemId = e.target.closest(".record-item").getAttribute("item-id");
 
-    store.deleteRecordFromStore(dateId, itemId);
+    deleteRecordsFromServer(dateId, itemId).then(() => {
+      store.deleteRecordFromStore(dateId, itemId);
+    });
   });
 }

--- a/scripts/records.js
+++ b/scripts/records.js
@@ -93,8 +93,8 @@ export const renderRecordByDate = ({ date, items }) => {
   recordContainerEl.innerHTML += `
     <div class="record-container">
       <div class="record-header">
-        <div class="record-date">${formattedDate}</div>
-        <div class="record-amount">${incomeContent}  ${outcomeContent}</div>
+        <div class="record-date font-serif-14">${formattedDate}</div>
+        <div class="record-amount font-serif-14">${incomeContent}  ${outcomeContent}</div>
       </div> ${recordsHTML}
     </div>
   `;
@@ -112,10 +112,12 @@ export const generateRecordHTML = (items) => {
     }
     itemsHTML += `
       <div class="record-item">
-        <div class="category ${item.category.replace(/\s+/g, "")}">${item.category}</div>
-        <div class="description">${item.description}</div>
-        <div class="payment">${item.payment}</div>
-        <div class="amount ${sign}">${formatWithComma(item.amount)}</div>
+        <div class="category font-light-12 ${item.category.replace(/\s+/g, "")}">${
+      item.category
+    }</div>
+        <div class="description font-light-14">${item.description}</div>
+        <div class="payment font-light-14">${item.payment}</div>
+        <div class="amount font-light-14 ${sign}">${formatWithComma(item.amount)}</div>
         
       </div>`;
   });

--- a/scripts/store.js
+++ b/scripts/store.js
@@ -21,8 +21,20 @@ export const store = {
     this.records = newRecords;
     this.notify();
   },
-  addRecordToStore(record) {
-    this.records.push(record);
+  addRecordToStore({ recordId, date, item }) {
+    // record에 추가하려는 날짜에 대한 정보가 이미 있나 확인
+    const foundRecord = this.records.find((record) => record.date.toString() === date.toString());
+    if (foundRecord) {
+      // 이미 있는 날짜라면 해당 날짜의 items 배열에 추가
+      foundRecord.items.push(item);
+    } else {
+      // 없는 날짜라면 record에 날짜 포함한 새 객체 생성
+      this.records.push({
+        id: recordId,
+        date,
+        items: [item],
+      });
+    }
     this.notify();
   },
   deleteRecordFromStore(dateId, itemId) {

--- a/scripts/store.js
+++ b/scripts/store.js
@@ -2,9 +2,16 @@ import { fetchRecords } from "../api/recordsApi.js";
 
 export const store = {
   records: [],
+  observers: [],
+  dateObservers: [],
+  currentDate: {
+    year: new Date().getFullYear(),
+    month: new Date().getMonth() + 1,
+  },
   init() {
     return fetchRecords().then((res) => {
       this.records = res;
+      this.notify();
     });
   },
   getRecords() {
@@ -12,11 +19,36 @@ export const store = {
   },
   setRecords(newRecords) {
     this.records = newRecords;
+    this.notify();
   },
-  addRecord(record) {
+  addRecordToStore(record) {
     this.records.push(record);
+    this.notify();
   },
-  deleteRecord(itemId) {
-    this.setRecords();
+  deleteRecordToStore(itemId) {
+    // todo: id에 해당하는 레코드 지워서 반영
+
+    this.notify();
+  },
+
+  getDate() {
+    return this.currentDate;
+  },
+  setDate(year, month) {
+    this.currentDate = { year, month };
+    this.notifyDate();
+  },
+  subscribe(callback) {
+    this.observers.push(callback);
+  },
+  subscribeDate(cb) {
+    this.dateObservers.push(cb);
+  },
+
+  notify() {
+    this.observers.forEach((cb) => cb(this.records));
+  },
+  notifyDate() {
+    this.dateObservers.forEach((cb) => cb(this.currentDate));
   },
 };

--- a/scripts/store.js
+++ b/scripts/store.js
@@ -25,8 +25,24 @@ export const store = {
     this.records.push(record);
     this.notify();
   },
-  deleteRecordToStore(itemId) {
-    // todo: id에 해당하는 레코드 지워서 반영
+  deleteRecordFromStore(dateId, itemId) {
+    this.records = this.records.reduce((acc, record) => {
+      // 삭제하려는 레코드의 날짜의 items 배열에 접근
+      if (record.id.toString() === dateId.toString()) {
+        const filteredItems = record.items.filter(
+          (item) => item.id.toString() !== itemId.toString()
+        );
+
+        // 삭제 결과 해당 날짜의 item이 남아있다면 남은 items를 반환
+        if (filteredItems.length > 0) {
+          acc.push({ ...record, items: filteredItems });
+        }
+        // item 배열이 없다면 해당 날짜의 객체는 사라짐
+      } else {
+        acc.push(record); // 삭제 대상 날짜가 아니므로 그대로 유지
+      }
+      return acc;
+    }, []);
 
     this.notify();
   },

--- a/scripts/subscribe.js
+++ b/scripts/subscribe.js
@@ -6,10 +6,7 @@ export function subscribeStore() {
   store.subscribe((records) => {
     const { year, month } = store.getDate();
     renderRecordHeader(year, month, records);
-    renderRecords(year, month, records, {
-      income: incomeVisible,
-      outcome: outcomeVisible,
-    });
+    renderRecords(year, month, records);
   });
   store.subscribeDate(({ year, month }) => {
     const records = store.getRecords();

--- a/scripts/subscribe.js
+++ b/scripts/subscribe.js
@@ -1,0 +1,21 @@
+import { store } from "./store.js";
+import { renderRecords, renderRecordHeader } from "./records.js";
+import { updateHeaderDateUI } from "./header.js";
+
+export function subscribeStore() {
+  store.subscribe((records) => {
+    const { year, month } = store.getDate();
+    renderRecordHeader(year, month, records);
+    renderRecords(year, month, records, {
+      income: incomeVisible,
+      outcome: outcomeVisible,
+    });
+  });
+  store.subscribeDate(({ year, month }) => {
+    const records = store.getRecords();
+
+    updateHeaderDateUI(year, month);
+    renderRecordHeader(year, month, records);
+    renderRecords(year, month, records);
+  });
+}


### PR DESCRIPTION
[시연 영상]

https://github.com/user-attachments/assets/71884376-43e2-4b3d-8ad1-461d7cdc2f8c




## 완료 작업 목록
- 폰트가 적용되지 않던 문제를 확장자 변경을 통해 수정했습니다. (.ttf -> .woff)
- 헤더의 날짜(연도, 월) 데이터도 store에서 관리되게끔 변경하였습니다.
- store에 간단한 observer를 추가해서 store 값이 변할 때 구독하는 함수들(렌더링)이 별도 호출 없이 실행되도록 변경했습니다.
- store 삭제 / api 삭제 기능을 구현했습니다.
- 수정할 내역을 클릭하면 해당 내역의 정보들이 input bar에 들어가도록 하고, 유효성 검사도 다시 진행되게 했습니다.

## 주요 고민과 해결 과정
1. add / delete 시에 store 수정 따로, api 호출 따로 진행되는데(데이터는 같음) api 호출이 실패했을 때 store와 서버의 데이터가 일치하지 않는 문제가 있어 어떤 식으로 코드를 구성해야하나 고민했습니다. -> store에 먼저 추가해서 우선 렌더링이 되게하고, 이후 api를 호출하는데, 실패시 rollback 코드를 구현하여 데이터의 일관성이 유지되게 할 계획입니다.(현재는 따로 호출 중)

2. store 객체 속 데이터를 변경하고, 렌더링 함수를 다시 호출해야하는 비효율성이 느껴져 고민하다가 간단한 observer를 store 내부에 구현했습니다. 이제 추가 / 수정 / 삭제 코드를 수행하면 렌더링 함수를 따로 호출할 필요 없이 store에서 구독중인 함수를 실행시켜줍니다. 불필요한 코드가 줄어들고 크게 함수 하나를 통째로 제거할 수 있었습니다.

3. (진행 중) 수정 모드를 확인하는 isEditMode 변수를 store에 둬야할 것 같아 고민 중입니다. 수정 로직에 대한 고민 이후 결정할 예정입니다.