### PR TITLE
[박종성] - 가계부의 세부내역을 클릭하면 폼으로 불러오고 수정 구현

### DIFF
--- a/data/dummy.json
+++ b/data/dummy.json
@@ -1,21 +1,6 @@
 {
   "summaries": [
     {
-      "id": "7a9a1d18-6953-47b6-8ed4-5c6f64b28e7e",
-      "date": "2025-07-14",
-      "sign": "-",
-      "amount": 8200,
-      "memo": "편의점 샌드위치",
-      "category": {
-        "value": "food",
-        "text": "식비"
-      },
-      "method": {
-        "value": "card",
-        "text": "현금"
-      }
-    },
-    {
       "id": "53f0488f-4bb2-4fc9-9b18-315db6e9d4be",
       "date": "2025-07-14",
       "sign": "-",
@@ -38,11 +23,11 @@
       "memo": "현대차 매수",
       "category": {
         "value": "culture",
-        "text": "문화/취미"
+        "text": "문화/여가"
       },
       "method": {
-        "value": "bank",
-        "text": "계좌이체"
+        "value": "card",
+        "text": "현금"
       }
     },
     {
@@ -53,11 +38,11 @@
       "memo": "영화 관람",
       "category": {
         "value": "culture",
-        "text": "문화/취미"
+        "text": "문화/여가"
       },
       "method": {
-        "value": "card",
-        "text": "현금"
+        "value": "cash",
+        "text": "신용카드"
       }
     },
     {

--- a/src/app/initDummyData.js
+++ b/src/app/initDummyData.js
@@ -1,0 +1,9 @@
+import {GetDummyData} from "../shared/data/dummyData.js";
+
+export const initDummyData = ({summaryStore}) => {
+    GetDummyData().then(dummy => {
+        dummy.forEach(e => {
+            summaryStore.dispatch('ENTRY/ADD', e)
+        });
+    })
+}

--- a/src/app/main.js
+++ b/src/app/main.js
@@ -8,6 +8,7 @@ const bootstrap = () => {
     // Store 생성
     const summaryStore = new Store({entries: []});
     const dateStore = new Store({year: 2000, month: 9});
+    const selectedEntryStore = new Store({selectedEntry: null});
 
     // 날짜쪽 UI 초기화
     initDateNav({navEl: document.querySelector('.month-nav'), dateStore: dateStore});
@@ -15,10 +16,15 @@ const bootstrap = () => {
     initSummaryView({
         summaryEl: document.querySelector('.month-summary'),
         summaryStore: summaryStore,
-        dateStore: dateStore
+        dateStore: dateStore,
+        selectedEntryStore: selectedEntryStore
     });
     // 입력폼 UI 초기화
-    initFormView({formEl: document.querySelector('.detail-form'), summaryStore: summaryStore});
+    initFormView({
+        formEl: document.querySelector('.detail-form'),
+        summaryStore: summaryStore,
+        selectedEntryStore: selectedEntryStore
+    });
 
     // 더미 데이터를 비동기(Promise) 방식으로 로드 후 스토어에 주입
     GetDummyData()

--- a/src/app/main.js
+++ b/src/app/main.js
@@ -2,7 +2,7 @@ import {Store} from './store.js';
 import {initDateNav} from '../domains/headerDate/ui/dateNav.js';
 import {initSummaryView} from '../domains/summary/ui/summaryView.js';
 import {initFormView} from '../domains/entryForm/ui/formView.js';
-import {loadDummyData} from '../shared/data/dummyData.js';
+import {GetDummyData} from '../shared/data/dummyData.js';
 
 const bootstrap = () => {
     // Store 생성
@@ -21,7 +21,7 @@ const bootstrap = () => {
     initFormView({formEl: document.querySelector('.detail-form'), summaryStore: summaryStore});
 
     // 더미 데이터를 비동기(Promise) 방식으로 로드 후 스토어에 주입
-    loadDummyData()
+    GetDummyData()
         .then(dummy => {
             dummy.forEach(e => summaryStore.dispatch('ENTRY/ADD', e));
         });

--- a/src/app/main.js
+++ b/src/app/main.js
@@ -2,7 +2,7 @@ import {Store} from './store.js';
 import {initDateNav} from '../domains/headerDate/ui/dateNav.js';
 import {initSummaryView} from '../domains/summary/ui/summaryView.js';
 import {initFormView} from '../domains/entryForm/ui/formView.js';
-import {initDummyData} from "./initDummyData.js";
+import {initDummyData} from "../shared/data/initDummyData.js";
 
 const bootstrap = () => {
     // Store 생성

--- a/src/app/main.js
+++ b/src/app/main.js
@@ -2,7 +2,7 @@ import {Store} from './store.js';
 import {initDateNav} from '../domains/headerDate/ui/dateNav.js';
 import {initSummaryView} from '../domains/summary/ui/summaryView.js';
 import {initFormView} from '../domains/entryForm/ui/formView.js';
-import {GetDummyData} from '../shared/data/dummyData.js';
+import {initDummyData} from "./initDummyData.js";
 
 const bootstrap = () => {
     // Store 생성
@@ -27,10 +27,7 @@ const bootstrap = () => {
     });
 
     // 더미 데이터를 비동기(Promise) 방식으로 로드 후 스토어에 주입
-    GetDummyData()
-        .then(dummy => {
-            dummy.forEach(e => summaryStore.dispatch('ENTRY/ADD', e));
-        });
+    initDummyData({summaryStore});
 };
 
 document.addEventListener('DOMContentLoaded', bootstrap);

--- a/src/app/store.js
+++ b/src/app/store.js
@@ -33,6 +33,33 @@ export class Store {
                 this.state = {...this.state, entries: this.state.entries.filter(e => e.id !== payload.id)};
                 break;
 
+            // store에서 엔트리를 업데이트하는 액션
+            case 'ENTRY/UPDATE': {
+                // 깊은 복사를 사용한 항목 업데이트
+                const updatedEntries = this.state.entries.map(entry => {
+                    if (entry.id !== payload.id) return entry;
+                    // JSON 직렬화/역직렬화를 통한 깊은 복사
+                    return JSON.parse(JSON.stringify(payload));
+                });
+
+                // 상태 업데이트
+                this.state = {...this.state, entries: updatedEntries};
+                break;
+            }
+
+            // store에서 엔트리를 선택하는 액션
+            case 'ENTRY/SELECT':
+                const entry = {...payload};
+                // 선택된 엔트리를 상태에 저장
+                this.state = {...this.state, selectedEntry: entry};
+                break;
+
+            // store에서 선택된 엔트리를 초기화하는 액션
+            case 'ENTRY/SELECT/CLEAR':
+                // 선택된 엔트리를 null로 초기화
+                this.state = {...this.state, selectedEntry: null};
+                break;
+
             // store의 날짜를 변경하는 액션
             case 'DATE/SET':
                 // payload에 있는 연도와 월을 기반으로 상태를 업데이트

--- a/src/app/store.js
+++ b/src/app/store.js
@@ -1,3 +1,36 @@
+// 액션 타입별 핸들러 함수를 정의
+const actionHandlers = {
+    'ENTRY/ADD': (state, payload) => {
+        const entry = {...payload};
+        return {...state, entries: [...state.entries, entry]};
+    },
+
+    'ENTRY/REMOVE': (state, payload) => {
+        return {...state, entries: state.entries.filter(e => e.id !== payload.id)};
+    },
+
+    'ENTRY/UPDATE': (state, payload) => {
+        const updatedEntries = state.entries.map(entry => {
+            if (entry.id !== payload.id) return entry;
+            return JSON.parse(JSON.stringify(payload));
+        });
+        return {...state, entries: updatedEntries};
+    },
+
+    'ENTRY/SELECT': (state, payload) => {
+        const entry = {...payload};
+        return {...state, selectedEntry: entry};
+    },
+
+    'ENTRY/SELECT/CLEAR': (state) => {
+        return {...state, selectedEntry: null};
+    },
+
+    'DATE/SET': (state, payload) => {
+        return {...state, year: payload.year, month: payload.month};
+    }
+};
+
 export class Store {
     // constructor를 통해 초기 상태를 설정
     constructor(initialState) {
@@ -18,57 +51,12 @@ export class Store {
     };
     // 상태를 변경하는 함수
     dispatch = (type, payload) => {
-        switch (type) {
-            // store에 새로운 엔트리를 추가하는 액션
-            case 'ENTRY/ADD': {
-                // payload에 있는 데이터를 기반으로 새로운 엔트리를 생성, ...payload를 통해 얕은 복사를 수행해서 새 객체를 생성
-                const entry = {...payload};
-                // 현재 상태의 entries 배열에 새 엔트리를 추가
-                this.state = {...this.state, entries: [...this.state.entries, entry]};
-                break;
-            }
-            // store에서 엔트리를 삭제하는 액션
-            case 'ENTRY/REMOVE':
-                // payload에 있는 id를 가진 엔트리를 찾아서 삭제
-                this.state = {...this.state, entries: this.state.entries.filter(e => e.id !== payload.id)};
-                break;
+        const handler = actionHandlers[type];
 
-            // store에서 엔트리를 업데이트하는 액션
-            case 'ENTRY/UPDATE': {
-                // 깊은 복사를 사용한 항목 업데이트
-                const updatedEntries = this.state.entries.map(entry => {
-                    if (entry.id !== payload.id) return entry;
-                    // JSON 직렬화/역직렬화를 통한 깊은 복사
-                    return JSON.parse(JSON.stringify(payload));
-                });
+        handler
+            ? this.state = handler(this.state, payload)
+            : console.warn('[Store] Unknown action:', type);
 
-                // 상태 업데이트
-                this.state = {...this.state, entries: updatedEntries};
-                break;
-            }
-
-            // store에서 엔트리를 선택하는 액션
-            case 'ENTRY/SELECT':
-                const entry = {...payload};
-                // 선택된 엔트리를 상태에 저장
-                this.state = {...this.state, selectedEntry: entry};
-                break;
-
-            // store에서 선택된 엔트리를 초기화하는 액션
-            case 'ENTRY/SELECT/CLEAR':
-                // 선택된 엔트리를 null로 초기화
-                this.state = {...this.state, selectedEntry: null};
-                break;
-
-            // store의 날짜를 변경하는 액션
-            case 'DATE/SET':
-                // payload에 있는 연도와 월을 기반으로 상태를 업데이트
-                this.state = {...this.state, year: payload.year, month: payload.month};
-                break;
-
-            default:
-                console.warn('[Store] Unknown action:', type);
-        }
         // 상태가 변경되면 인자로 받았던 함수들을 호출
         this.listeners.forEach(fn => fn(this.state));
     };

--- a/src/domains/summary/ui/summaryView.js
+++ b/src/domains/summary/ui/summaryView.js
@@ -34,15 +34,9 @@ const clearDayGroups = ({summaryEl}) => {
 // 항목 하나를 DOM에 렌더링하는 함수
 const renderSingleEntry = ({group, entry}) => {
     const entriesContainer = group.querySelector('.entries');
-
-    // 고유 키 생성 (원래 entryHTML에서 생성된다고 가정)
     const uniqueKey = crypto.randomUUID();
-
-    // HTML 생성 전에 고유 키 설정
     const html = entryHTML({entry, entryKey: uniqueKey});
     entriesContainer.insertAdjacentHTML('beforeend', html);
-
-    // 방금 추가된 요소 반환
     return {
         key: uniqueKey,
         id: entry.id,
@@ -53,13 +47,11 @@ const renderSingleEntry = ({group, entry}) => {
 // 항목 목록을 DOM에 렌더링
 const renderEntries = ({summaryEl, entries}) => {
     const renderedItems = [];
-
     entries.forEach(entry => {
         const group = ensureGroup({summaryEl, date: entry.date});
         const renderedItem = renderSingleEntry({group, entry});
         renderedItems.push(renderedItem);
     });
-
     return renderedItems;
 };
 
@@ -86,85 +78,137 @@ const updateTotalSummary = ({summaryEl, entries}) => {
     summaryEl.querySelector('.total.income-spend').textContent = formatSummaryText({calcResult: totals});
 };
 
-export const initSummaryView = ({summaryEl, summaryStore, dateStore}) => {
-    // 현재 선택된 연월 상태
-    let currentYear = null;
-    let currentMonth = null;
+// 현재 필터링 상태로 UI 렌더링
+const renderView = ({summaryEl, summaryStore, entryKeyMap, currentYear, currentMonth}) => {
+    // 기존 id와 키 매핑 초기화
+    entryKeyMap.clear();
+
+    const allEntries = summaryStore.getState().entries || [];
+    const filteredEntries = filterEntriesByYearMonth({entries: allEntries, year: currentYear, month: currentMonth});
+    const sortedEntries = [...filteredEntries].sort(sortByDateDesc);
+
+    // 기존의 하드코딩된 날짜 그룹 제거
+    clearDayGroups({summaryEl});
+
+    // 날짜별 그룹 생성 및 항목 렌더링
+    const renderedElements = renderEntries({summaryEl, entries: sortedEntries});
+    // 항목 요소와 ID 매핑 업데이트
+    updateEntryKeyMap({renderedElements, entryKeyMap});
+    // 날짜별 합계 업데이트
+    updateDayTotals({summaryEl, entries: filteredEntries});
+    // 전체 합계 업데이트
+    updateTotalSummary({summaryEl, entries: filteredEntries});
+};
+
+// 항목 삭제 처리
+const handleEntryDelete = ({e, entryKeyMap, summaryStore}) => {
+    const deleteButton = e.target.closest('.delete-btn');
+    if (!deleteButton) return;
+
+    const entryItem = deleteButton.closest('.entry');
+    if (!entryItem || !entryItem.dataset.entryKey) return;
+
+    // 키-ID 맵에서 실제 ID 조회
+    const entryKey = entryItem.dataset.entryKey;
+    const entryId = entryKeyMap.get(entryKey);
+
+    if (!entryId) return;
+
+    DeleteDummyData(entryId).then(() => {
+        // 성공적으로 삭제된 후 상태 업데이트
+        summaryStore.dispatch('ENTRY/REMOVE', {id: entryId});
+    }).catch((error) => {
+        console.error('Error deleting entry:', error);
+    });
+};
+
+// 항목 선택 처리 함수
+const handleEntrySelect = ({e, entryKeyMap, summaryStore, selectedEntryStore}) => {
+    // 삭제 버튼이 클릭된 경우는 무시
+    if (e.target.closest('.delete-btn')) return;
+
+    // entry 항목 요소를 찾음
+    const entryItem = e.target.closest('.entry');
+    if (!entryItem || !entryItem.dataset.entryKey) return;
+
+    // 키-ID 맵에서 실제 ID 조회
+    const entryKey = entryItem.dataset.entryKey;
+    const entryId = entryKeyMap.get(entryKey);
+
+    if (!entryId) return;
+
+    // 해당 ID의 항목 데이터 찾기
+    const allEntries = summaryStore.getState().entries || [];
+    const selectedEntry = allEntries.find(entry => entry.id === entryId);
+
+    if (!selectedEntry) return;
+
+    // 선택된 항목을 스토어에 디스패치
+    selectedEntryStore.dispatch('ENTRY/SELECT', selectedEntry);
+};
+
+// dateStore 상태 변경 처리
+const handleDateChange = ({state, currentState, renderView, summaryEl, summaryStore, entryKeyMap}) => {
+    if (state.year !== currentState.year || state.month !== currentState.month) {
+        currentState.year = state.year;
+        currentState.month = state.month;
+        renderView({
+            summaryEl,
+            summaryStore,
+            entryKeyMap,
+            currentYear: currentState.year,
+            currentMonth: currentState.month
+        });
+    }
+};
+
+export const initSummaryView = ({summaryEl, summaryStore, dateStore, selectedEntryStore}) => {
+    // 현재 선택된 연월 상태를 객체로 관리
+    const currentState = {
+        year: null,
+        month: null
+    };
 
     // 항목 키와 ID의 매핑을 저장하는 객체
     const entryKeyMap = new Map();
 
-    // 현재 필터링 상태로 UI 렌더링
-    const renderView = () => {
-        // 기존 id와 키 매핑 초기화
-        entryKeyMap.clear();
-
-        const allEntries = summaryStore.getState().entries || [];
-        const filteredEntries = filterEntriesByYearMonth({entries: allEntries, year: currentYear, month: currentMonth});
-        const sortedEntries = [...filteredEntries].sort(sortByDateDesc);
-
-        // 기존의 하드코딩된 날짜 그룹 제거
-        clearDayGroups({summaryEl});
-
-        // 날짜별 그룹 생성 및 항목 렌더링
-        const renderedElements = renderEntries({summaryEl, entries: sortedEntries});
-        // 항목 요소와 ID 매핑 업데이트
-        updateEntryKeyMap({renderedElements, entryKeyMap});
-        // 날짜별 합계 업데이트
-        updateDayTotals({summaryEl, entries: filteredEntries});
-        // 전체 합계 업데이트
-        updateTotalSummary({summaryEl, entries: filteredEntries});
-    };
-
-    // 항목 삭제 처리
-    const handleEntryDelete = (e) => {
-        const deleteButton = e.target.closest('.delete-btn');
-        if (!deleteButton) return;
-
-        const entryItem = deleteButton.closest('.entry');
-
-        if (!entryItem || !entryItem.dataset.entryKey) return;
-
-        // 키-ID 맵에서 실제 ID 조회
-        const entryKey = entryItem.dataset.entryKey;
-        const entryId = entryKeyMap.get(entryKey);
-
-        if (!entryId) return;
-
-        DeleteDummyData(entryId).then(() => {
-                // 성공적으로 삭제된 후 상태 업데이트
-                summaryStore.dispatch('ENTRY/REMOVE', {id: entryId});
-            }
-        ).catch(
-            (error) => {
-                console.error('Error deleting entry:', error);
-            }
-        )
-    };
-
-    // dateStore 상태 변경 처리
-    const handleDateChange = (state) => {
-        if (state.year !== currentYear || state.month !== currentMonth) {
-            currentYear = state.year;
-            currentMonth = state.month;
-            renderView();
-        }
-    };
-
     // 이벤트 리스너 등록
-    summaryEl.addEventListener('click', handleEntryDelete);
+    summaryEl.addEventListener('click', (e) => {
+        handleEntryDelete({e, entryKeyMap, summaryStore});
+        handleEntrySelect({e, entryKeyMap, summaryStore, selectedEntryStore});
+    });
 
     // Store 구독
-    summaryStore.subscribe(renderView);
-    dateStore.subscribe(handleDateChange);
+    summaryStore.subscribe(() => renderView({
+        summaryEl,
+        summaryStore,
+        entryKeyMap,
+        currentYear: currentState.year,
+        currentMonth: currentState.month
+    }));
+
+    dateStore.subscribe((state) => handleDateChange({
+        state,
+        currentState,
+        renderView,
+        summaryEl,
+        summaryStore,
+        entryKeyMap
+    }));
 
     // 초기 상태 설정
     const dateState = dateStore.getState();
     if (dateState && dateState.year && dateState.month) {
-        currentYear = dateState.year;
-        currentMonth = dateState.month;
+        currentState.year = dateState.year;
+        currentState.month = dateState.month;
     }
 
     // 초기 렌더링
-    renderView();
+    renderView({
+        summaryEl,
+        summaryStore,
+        entryKeyMap,
+        currentYear: currentState.year,
+        currentMonth: currentState.month
+    });
 };

--- a/src/shared/components/modal.js
+++ b/src/shared/components/modal.js
@@ -18,13 +18,13 @@ export const showModal = (onConfirm) => {
   const input = overlay.querySelector('.modal-input');
 
   // 취소 버튼 클릭 시 모달을 닫음
-  overlay.querySelector('.cancel').onclick = close;
+  overlay.querySelector('.cancel').addEventListener('click', close)
   // 추가 버튼 클릭 시
-  overlay.querySelector('.confirm').onclick = () => {
+  overlay.querySelector('.confirm').addEventListener('click', ()=>{
     // 입력 필드의 값을 가져와 공백을 제거
     const v = input.value.trim();
     // 입력값이 비어있지 않으면 onConfirm 함수 호출
     if (v) onConfirm(v);
     close();
-  };
+  })
 };

--- a/src/shared/constants/jsonServerUrl.js
+++ b/src/shared/constants/jsonServerUrl.js
@@ -1,0 +1,1 @@
+export const DUMMY_DATA_URL = 'http://localhost:1080/summaries';

--- a/src/shared/data/dummyData.js
+++ b/src/shared/data/dummyData.js
@@ -1,4 +1,4 @@
-import { DUMMY_DATA_URL } from '../constants/jsonServerUrl';
+import { DUMMY_DATA_URL } from '../constants/jsonServerUrl.js';
 
 // 더미데이터를 로드하는 함수
 export const GetDummyData = () =>

--- a/src/shared/data/dummyData.js
+++ b/src/shared/data/dummyData.js
@@ -1,7 +1,7 @@
-const DUMMY_DATA_URL = 'http://localhost:1080/summaries';
+import { DUMMY_DATA_URL } from '../constants/jsonServerUrl';
 
 // 더미데이터를 로드하는 함수
-export const loadDummyData = () =>
+export const GetDummyData = () =>
     fetch(DUMMY_DATA_URL)
         .then(res => (res.ok ? res.json() : []))
         .catch(err => {
@@ -22,7 +22,19 @@ export const PostDummyData = (data) =>
             return Promise.reject(err);
         });
 
-// 더미데이터를 서버에 PUT이나 PATCH 요청으로 수정하는 함수, DELETE 요청으로 삭제하는 함수 구현 예정
+// 더미데이터를 서버에 PUT 요청으로 수정하는 함수
+export const PuTDummyData = (id, data) =>
+    fetch(`${DUMMY_DATA_URL}/${id}`, {
+        method: 'PUT',
+        headers: {
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(data),
+    })
+        .then(res => (res.ok ? res.json() : Promise.reject(res)))
+        .catch(err => {
+            return Promise.reject(err);
+        });
 
 
 // 더미데이터를 서버에 DELETE 요청으로 삭제하는 함수

--- a/src/shared/data/initDummyData.js
+++ b/src/shared/data/initDummyData.js
@@ -1,4 +1,4 @@
-import {GetDummyData} from "../shared/data/dummyData.js";
+import {GetDummyData} from "./dummyData.js";
 
 export const initDummyData = ({summaryStore}) => {
     GetDummyData().then(dummy => {


### PR DESCRIPTION


https://github.com/user-attachments/assets/da9d2ab7-f41e-4785-b7fb-55ecb018152b



## 완료 작업 목록
- 가계부의 세부내역을 입력폼으로 불러오기

- 불러온 세부내역을 수정하고 제출 시 PUT요청 및 렌더링에 반영

- 옵저버 패턴과 지금 코드의 패턴 비교

## 주요 고민과 해결 과정
- 가계부의 세부내역을 어떻게 불러올지 고민
   -> summaryView에서 formView로 전달해야했음
   -> store를 통해 전역적으로 관리하는 것이 좋다고 판단
   -> 기존의 summaryStore에 추가적으로 관리하는 것보다 관리의 측면에서 아예 새로 selectedEntryStore로 구현하는 것이 낫다고 판단

- 불러온 세부내역을 수정한 후 PUT요청을 통해 서버 데이터는 잘 변경되지만 렌더링이 바로 되지 않음
   -> 기존의 generateData함수에서 id를 새롭게 부여해서 기존의 id가 사라지고 새로운 id가 할당되는 오류, 기존에 id가 있는 경우는 새로 부여하지 않도록 수정

- 옵저버 패턴의 경우 subject와 observer클래스 필요
   -> subject는 상태 저장 및 **observer에게 상태 변경 알림**
   -> subject가 구독자들인 observer의 내부로직을 실행하도록 notify실행
   -> subject가 observer의 내부로직 함수명을 알고 있어야 함 -> 의존성

- 지금의 패턴(dispatcher 사용)은 observer가 따로 없고 subscriber에 실행할 함수들을 등록(listener에 등록)
   -> 구독자들(함수들)에 state를 인자로 주면서 실행 -> 더 느슨한 결합
   -> 하지만 작은 프로젝트나 기존 코드베이스 통합에는 오버헤드가 있을 수 있다는 단점 존재
