### PR TITLE
[김미소] - 수입지출내역 수정 및 필터링 구현, 드롭다운 커스텀 구현

### DIFF
--- a/assets/icons/check_btn_squre_cancelled.svg
+++ b/assets/icons/check_btn_squre_cancelled.svg
@@ -1,0 +1,4 @@
+<svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="0.333496" y="0.333344" width="13.3333" height="13.3333" rx="3" fill="white" stroke="black"/>
+<path d="M10.3337 5L5.75033 9.44444L3.66699 7.42424" stroke="white" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/assets/icons/chevron-down.svg
+++ b/assets/icons/chevron-down.svg
@@ -1,0 +1,3 @@
+<svg width="17" height="16" viewBox="0 0 17 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12.1665 6L8.1665 10L4.1665 6" stroke="black" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/assets/icons/closed.svg
+++ b/assets/icons/closed.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M7.75732 7.75735L16.2426 16.2426" stroke="#E93B5A" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M7.75732 16.2426L16.2426 7.75736" stroke="#E93B5A" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/global.css
+++ b/global.css
@@ -1,9 +1,17 @@
+@font-face {
+    font-family: 'Ownglyph_corncorn-Rg';
+    src: url('https://fastly.jsdelivr.net/gh/projectnoonnu/2412-1@1.0/Ownglyph_corncorn-Rg.woff2') format('woff2');
+    font-weight: normal;
+    font-style: normal;
+}
+
 body {
     margin: 0;
+    font-family: 'Ownglyph_corncorn-Rg', sans-serif;
 }
 
 .header {
-    background-color: #ababab;
+    background-color: #a3b2e4;
     border-bottom: 1px solid #000000;
     padding: 40px 273px 64px 273px
 }
@@ -127,4 +135,54 @@ body {
 
 .mr-1 {
     margin-right: 4px;
+}
+
+.mr-2 {
+    margin-right: 8px;
+}
+
+span {
+    font-family: 'Ownglyph_corncorn-Rg', sans-serif;
+}
+
+/* DropDown */
+.selected {
+    width: 104px;
+}
+
+.dropdown-block-container {
+    background-color: rgb(157, 218, 198);
+    width: 152px;
+    position: absolute;
+    z-index: 3;
+}
+
+ul {
+    padding: 0;
+    transform: translate(-25px, 12px);
+}
+
+.category-field li {
+    list-style-type: none;
+    height: 56px;
+    padding: 0 24px;
+    font-size: 12px;
+}
+
+.category-field:hover {
+    cursor: pointer;
+}
+
+.option-list {
+    border-bottom: 1px solid #000000;
+}
+
+.option-list:hover {
+    background: rgb(72, 106, 180);
+    cursor: pointer;
+}
+
+.selected-value {
+    color: #777D84;
+    font-size: 12px;
 }

--- a/global.css
+++ b/global.css
@@ -182,11 +182,12 @@ ul {
     cursor: pointer;
 }
 
-.selected-value{
+.selected-value {
     font-size: 12px;
     color: black;
 }
+
 .selected-value-placeholder {
     color: #777D84;
-    
+
 }

--- a/global.css
+++ b/global.css
@@ -146,7 +146,7 @@ span {
 }
 
 /* DropDown */
-.selected {
+.selectedDropDown {
     width: 104px;
 }
 
@@ -182,7 +182,11 @@ ul {
     cursor: pointer;
 }
 
-.selected-value {
-    color: #777D84;
+.selected-value{
     font-size: 12px;
+    color: black;
+}
+.selected-value-placeholder {
+    color: #777D84;
+    
 }

--- a/mock/DummyData.json
+++ b/mock/DummyData.json
@@ -121,7 +121,7 @@
                         "date": "2025-07-01",
                         "category": "월급",
                         "description": "프리랜서 프로젝트",
-                        "method": "이체",
+                        "method": "현금",
                         "type": "income",
                         "amount": 120000
                     },
@@ -130,7 +130,7 @@
                         "date": "2025-07-01",
                         "category": "식비",
                         "description": "점심 김밥",
-                        "method": "국민카드",
+                        "method": "신용카드",
                         "type": "expenses",
                         "amount": -8000
                     },
@@ -139,7 +139,7 @@
                         "date": "2025-07-01",
                         "category": "교통",
                         "description": "버스 요금",
-                        "method": "티머니",
+                        "method": "현금",
                         "type": "expenses",
                         "amount": -16000
                     }

--- a/src/components/DailyListBlock/DailyListBlock.js
+++ b/src/components/DailyListBlock/DailyListBlock.js
@@ -16,12 +16,12 @@ function DailyListBlock({ data, onSelect }) {
                 ${TagBox({ value: data.category }).element}
                 <span class="content-row__info">${data.description}</span>
                 <span class="content-row__method">${data.method}</span>
-                <span class="content-row__amount">${formatAmount(data.amount)}원</span>
+                <span class="content-row__amount" style="color: ${data.amount < 0 ? '#C04646' : '#79B2CA'};">${formatAmount(data.amount)}원</span>
 
                 <div class="delete-button" style="display: none;">
                     <button class="flex-row button" id="delete-button-${data.blockId}">
                         <img src="assets/icons/close-red.svg" alt="삭제 아이콘" class="mr-1">
-                        <span> 삭제</span>
+                        <span style="color: #E93B5A;"> 삭제</span>
                     </button>
                 </div>
             </div>

--- a/src/components/DropDown/DropDown.js
+++ b/src/components/DropDown/DropDown.js
@@ -1,21 +1,21 @@
 import DropDownBlock from "./DropDownBlock.js";
 
-function DropDown({ options, editable, id, onChange }) {
+function DropDown({ options, editable, id, onChange, onAdd, onDelete }) {
     let isOpen = false;
 
     const renderOptions = (optionsList) =>
-      optionsList
-        .map(
-          (option) =>
-            DropDownBlock({ id: option, value: option, editable }).element
-        )
-        .join("") +
-      (editable
-        ? `<li class="option-list flex-row" value="기타">추가하기</li>`
-        : "");
+        optionsList
+            .map(
+                (option) =>
+                    DropDownBlock({ id: option, value: option, editable }).element
+            )
+            .join("") +
+        (editable
+            ? `<li class="option-list flex-row" value="추가하기">추가하기</li>`
+            : "");
 
     return {
-      element: `
+        element: `
             <div class="category-field" id="${id}">
                 <div class="selectedDropDown flex-row">
                     <div class="selected-value selected-value-placeholder">선택하세요</div>
@@ -28,45 +28,64 @@ function DropDown({ options, editable, id, onChange }) {
                 </ul>
             </div>
         `,
-      init: () => {
-        const dropdown = document.getElementById(id);
-        const selectedValue = dropdown.querySelector(".selectedDropDown");
-        const dropdownList = dropdown.querySelector(
-          ".dropdown-block-container"
-        );
+        init: () => {
+            const dropdown = document.getElementById(id);
+            const selectedValue = dropdown.querySelector(".selectedDropDown");
+            const dropdownList = dropdown.querySelector(
+                ".dropdown-block-container"
+            );
 
-        selectedValue.addEventListener("click", () => {
-          isOpen = !isOpen;
-          if (isOpen) {
-            dropdownList.style.display = "block";
-            selectedValue.classList.add("rotate");
-          } else {
-            dropdownList.style.display = "none";
-            selectedValue.classList.remove("rotate");
-          }
-        });
+            selectedValue.addEventListener("click", () => {
+                isOpen = !isOpen;
+                if (isOpen) {
+                    dropdownList.style.display = "block";
+                    selectedValue.classList.add("rotate");
+                } else {
+                    dropdownList.style.display = "none";
+                    selectedValue.classList.remove("rotate");
+                }
+            });
 
-        dropdownList.addEventListener("click", (event) => {
-          if (event.target.classList.contains("option-list")) {
-            const selectedText = selectedValue.querySelector(".selected-value");
-            selectedText.textContent = event.target.textContent.trim();
-            dropdown.value = event.target.textContent.trim();
+            dropdownList.addEventListener("click", (event) => {
+                const li = event.target.closest("li.option-list");
+                if (!li) return;
 
-            selectedText.classList.remove("selected-value-placeholder");
-            dropdownList.style.display = "none";
+                const value = li.getAttribute("value");
 
-            if (typeof onChange === "function") {
-              onChange(dropdown.value);
-            }
-          }
-        });
-      },
-      updateOptions: (newOptions) => {
-        const dropdownList = document
-          .getElementById(id)
-          .querySelector(".dropdown-block-container");
-        dropdownList.innerHTML = renderOptions(newOptions);
-      },
+                // 삭제 버튼이 눌렸는지 확인
+                if (event.target.closest("button.icon-button")) {
+                    if (editable && typeof onDelete === "function") {
+                        onDelete(value); // value 기반 삭제 요청
+                    }
+                    event.stopPropagation();
+                    return;
+                }
+
+                // "추가하기" 항목 클릭
+                if (editable && value === "추가하기") {
+                    if (typeof onAdd === "function") onAdd();
+                    return;
+                }
+
+                const selectedText = selectedValue.querySelector(".selected-value");
+                selectedText.textContent = event.target.textContent.trim();
+                dropdown.value = event.target.textContent.trim();
+
+                selectedText.classList.remove("selected-value-placeholder");
+                dropdownList.style.display = "none";
+
+                if (typeof onChange === "function") {
+                    onChange(dropdown.value);
+                }
+
+            });
+        },
+        updateOptions: (newOptions) => {
+            const dropdownList = document
+                .getElementById(id)
+                .querySelector(".dropdown-block-container");
+            dropdownList.innerHTML = renderOptions(newOptions);
+        },
     };
 }
 export default DropDown;

--- a/src/components/DropDown/DropDown.js
+++ b/src/components/DropDown/DropDown.js
@@ -1,14 +1,51 @@
 import DropDownBlock from "./DropDownBlock.js";
 
 function DropDown({ options, editable, id }) {
+    let isOpen = false;
     return {
         element: `
-            <select class="category-field" id="${id}">
-                <option value="" disabled selected>선택하세요.</option>
-                ${options.map(option => DropDownBlock({ id: option, value: option, editable }).element).join('')}
-                ${editable ? `<option value="기타">추가하기</option>` : ''}
-            </select>
+            <div class="category-field" id="${id}">
+                <div class="selected flex-row">
+                    <div class="selected-value">선택하세요</div>
+                    <div class="arrow">
+                        <img src="assets/icons/chevron-down.svg" alt="arrow" />
+                    </div>
+                </div>
+                <ul class="dropdown-block-container" style="display: none;">
+                    ${options.map(option => DropDownBlock({ id: option, value: option, editable }).element).join('')}
+                    ${editable ? `<li class="option-list flex-row" value="기타">추가하기</li>` : ''}
+                </ul>
+            </div>
         `
+        ,
+        init: () => {
+            const dropdown = document.getElementById(id);
+            const selectedValue = dropdown.querySelector('.selected');
+            const dropdownList = dropdown.querySelector('.dropdown-block-container');
+
+            selectedValue.addEventListener('click', () => {
+                isOpen = !isOpen;
+                if (isOpen) {
+                    dropdownList.style.display = 'block';
+                    selectedValue.classList.add('rotate');
+                } else {
+                    dropdownList.style.display = 'none';
+                    selectedValue.classList.remove('rotate');
+                }
+            });
+
+            dropdownList.addEventListener('click', (event) => {
+                if (event.target.classList.contains('option-list')) {
+                    const selectedText = selectedValue.querySelector('.selected-value');
+                    selectedText.textContent = event.target.textContent.trim();
+                    dropdown.value = event.target.textContent.trim();
+
+                    selectedText.style.color = '#000';
+                    dropdownList.style.display = 'none';
+
+                }
+            });
+        }
     }
 }
 export default DropDown;

--- a/src/components/DropDown/DropDown.js
+++ b/src/components/DropDown/DropDown.js
@@ -1,51 +1,72 @@
 import DropDownBlock from "./DropDownBlock.js";
 
-function DropDown({ options, editable, id }) {
+function DropDown({ options, editable, id, onChange }) {
     let isOpen = false;
+
+    const renderOptions = (optionsList) =>
+      optionsList
+        .map(
+          (option) =>
+            DropDownBlock({ id: option, value: option, editable }).element
+        )
+        .join("") +
+      (editable
+        ? `<li class="option-list flex-row" value="기타">추가하기</li>`
+        : "");
+
     return {
-        element: `
+      element: `
             <div class="category-field" id="${id}">
-                <div class="selected flex-row">
-                    <div class="selected-value">선택하세요</div>
+                <div class="selectedDropDown flex-row">
+                    <div class="selected-value selected-value-placeholder">선택하세요</div>
                     <div class="arrow">
                         <img src="assets/icons/chevron-down.svg" alt="arrow" />
                     </div>
                 </div>
                 <ul class="dropdown-block-container" style="display: none;">
-                    ${options.map(option => DropDownBlock({ id: option, value: option, editable }).element).join('')}
-                    ${editable ? `<li class="option-list flex-row" value="기타">추가하기</li>` : ''}
+                    ${renderOptions(options)}
                 </ul>
             </div>
-        `
-        ,
-        init: () => {
-            const dropdown = document.getElementById(id);
-            const selectedValue = dropdown.querySelector('.selected');
-            const dropdownList = dropdown.querySelector('.dropdown-block-container');
+        `,
+      init: () => {
+        const dropdown = document.getElementById(id);
+        const selectedValue = dropdown.querySelector(".selectedDropDown");
+        const dropdownList = dropdown.querySelector(
+          ".dropdown-block-container"
+        );
 
-            selectedValue.addEventListener('click', () => {
-                isOpen = !isOpen;
-                if (isOpen) {
-                    dropdownList.style.display = 'block';
-                    selectedValue.classList.add('rotate');
-                } else {
-                    dropdownList.style.display = 'none';
-                    selectedValue.classList.remove('rotate');
-                }
-            });
+        selectedValue.addEventListener("click", () => {
+          isOpen = !isOpen;
+          if (isOpen) {
+            dropdownList.style.display = "block";
+            selectedValue.classList.add("rotate");
+          } else {
+            dropdownList.style.display = "none";
+            selectedValue.classList.remove("rotate");
+          }
+        });
 
-            dropdownList.addEventListener('click', (event) => {
-                if (event.target.classList.contains('option-list')) {
-                    const selectedText = selectedValue.querySelector('.selected-value');
-                    selectedText.textContent = event.target.textContent.trim();
-                    dropdown.value = event.target.textContent.trim();
+        dropdownList.addEventListener("click", (event) => {
+          if (event.target.classList.contains("option-list")) {
+            const selectedText = selectedValue.querySelector(".selected-value");
+            selectedText.textContent = event.target.textContent.trim();
+            dropdown.value = event.target.textContent.trim();
 
-                    selectedText.style.color = '#000';
-                    dropdownList.style.display = 'none';
+            selectedText.classList.remove("selected-value-placeholder");
+            dropdownList.style.display = "none";
 
-                }
-            });
-        }
-    }
+            if (typeof onChange === "function") {
+              onChange(dropdown.value);
+            }
+          }
+        });
+      },
+      updateOptions: (newOptions) => {
+        const dropdownList = document
+          .getElementById(id)
+          .querySelector(".dropdown-block-container");
+        dropdownList.innerHTML = renderOptions(newOptions);
+      },
+    };
 }
 export default DropDown;

--- a/src/components/DropDown/DropDownBlock.js
+++ b/src/components/DropDown/DropDownBlock.js
@@ -1,7 +1,10 @@
-function DropDownBlock({id, value, editable}) {
-    return{
+function DropDownBlock({ id, value, editable }) {
+    return {
         element: `
-            <option value="${value}">${value}</option>
+            <li class="option-list flex-row" value="${value}">
+                ${value}
+                ${editable ? `<button class="icon-button" id="${id}"><img src="assets/icons/closed.svg" alt="edit icon"></button>` : ''}
+            </li>
         `,
     }
 }

--- a/src/components/TagBox/TagBox.js
+++ b/src/components/TagBox/TagBox.js
@@ -1,7 +1,21 @@
+const COLOR = {
+    '생활': '#A7B9E9',
+    '문화/여가': '#BDA6E1',
+    '미분류': '#F0B0D3',
+    '교통': '#7DB7BF',
+    '식비': '#C5E0EB',
+    '의료/건강': '#BCDFD3',
+    '용돈': '#AACD7E',
+    '기타 수입': '#A28878',
+    '쇼핑/뷰티': '#D7CA6B',
+    '월급': '#E39D5D',
+};
+// by. bobob0311
+
 function TagBox({ value }) {
     return {
         element: `
-            <div class="tag-box">
+            <div class="tag-box" style="background-color: ${COLOR[value] || '#E0E0E0'}">
                 <span class="tag">${value}</span>
             </div>
         `

--- a/src/components/modal/Modal.css
+++ b/src/components/modal/Modal.css
@@ -1,0 +1,56 @@
+.modal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.5);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.modal-container {
+    background-color: #fff;
+    border-radius: 4px;
+
+    /* width: 400px; */
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+    align-items: center;
+}
+
+.modal-content {
+    padding: 32px;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+}
+
+.modal-title {
+    font-size: 16px;
+    margin-bottom: 8px;
+}
+
+.modal-text-area {
+    background-color: #F1F4F8;
+    border: none;
+    border-radius: 8px;
+    width: 320px;
+    /* height: 40px; */
+}
+
+.modal-text-area:focus {
+    outline: none;
+}
+
+.modal-footer {
+    width: 100%;
+}
+
+.modal-button {
+    flex: 1;
+    border: 1px solid black;
+    background-color: #fff;
+    height: 56px;
+    cursor: pointer;
+}

--- a/src/components/modal/Modal.js
+++ b/src/components/modal/Modal.js
@@ -1,0 +1,55 @@
+import { loadCSS } from "../../utils/cssLoader.js";
+import ModalContent from "./ModalContent.js";
+
+function Modal({ type, value, callback }) {
+    loadCSS('./src/components/modal/Modal.css', 'modal-css');
+
+    return {
+        element: `
+            <div class="modal">
+                <div class="modal-container flex-column">
+
+                    ${ModalContent({ readonly: type === 'deletePayment', type, value, onChange: (newValue) => value = newValue }).element}
+
+                    <div class="modal-footer flex-row">
+                        <button class="modal-button close-button">취소</button>
+                        <button class="modal-button confirm-button">${type === 'add' ? '추가' : '삭제'}</button>
+                    </div>
+                </div>
+            </div>
+        `,
+        init: () => {
+            console.log('Modal initialized with type:', type, 'and value:', value);
+            ModalContent({ readonly: type === 'deletePayment', type, value, onChange: (newValue) => value = newValue }).init();
+
+            const modal = document.querySelector('.modal');
+            const closeButton = modal.querySelector('.close-button');
+
+            // 모달 닫기 버튼 이벤트
+            closeButton.addEventListener('click', () => {
+                console.log('Modal closed');
+                modal.style.display = 'none';
+            });
+
+            // 모달 표시
+            modal.style.display = 'block';
+
+            // 확인 버튼 이벤트
+            const confirmButton = modal.querySelector('.confirm-button');
+            confirmButton.addEventListener('click', () => {
+                callback(type, value);
+                modal.style.display = 'none';
+            });
+
+            // 모달 내용 설정
+            const modalContent = modal.querySelector('.modal-content');
+            if (type === 'add') {
+                modalContent.innerHTML = `<p>${value}</p>`;
+            } else if (type === 'delete') {
+                modalContent.innerHTML = `<p class="error">${value}</p>`;
+            }
+        }
+    }
+};
+
+export default Modal;

--- a/src/components/modal/ModalContent.js
+++ b/src/components/modal/ModalContent.js
@@ -1,0 +1,43 @@
+import { loadCSS } from "../../utils/cssLoader.js";
+const titleMap = {
+    'add': '추가하실 결제 수단을 입력해주세요.',
+    'deletePayment': '해당 결제 수단을 삭제하시겠습니까?',
+    'deleteBlock': '해당 내역을 삭제하시겠습니까?',
+};
+
+function ModalContent({ readonly, type, value, onChange }) {
+
+    loadCSS('./src/components/modal/Modal.css', 'modal-css');
+    const textFiledContent = `
+        <div class="modal-text-field flex-column">
+            <textarea class="modal-text-area" ${readonly ? 'readonly' : ''}>${value}</textarea>
+        </div>
+    `;
+
+    const textContent = `
+        <div class="modal-text-field">
+            <span>${value}</span>
+        </div>
+    `;
+    return {
+        element: `
+            <div class="modal-content">
+                <span class="modal-title">${titleMap[type]}</span>
+                ${type === 'add' || type === 'deletePayment' ? textFiledContent : textContent}
+            </div>
+        `,
+        init: () => {
+            console.log('ModalContent initialized with type:', type, 'and value:', value);
+            if (type !== 'deleteBlock') {
+                const textArea = document.querySelector('.modal-text-area');
+
+                if (type === 'add') {
+                    textArea.addEventListener('input', (event) => {
+                        onChange(event.target.value);
+                    });
+                }
+            }
+        }
+    }
+};
+export default ModalContent;

--- a/src/layout/Header.js
+++ b/src/layout/Header.js
@@ -33,7 +33,7 @@ function Header() {
                     <div class="flex-row">
                         <span class="logo">Wise Wallet</span>
                         <div class="flex-row">
-                            <button class="arrow-icon" id="prev-month">
+                            <button class="arrow-icon icon-button" id="prev-month">
                                 <img src="assets/icons/chevron-left.svg" alt="이전 달">
                             </button>
                             <div class="date-container">
@@ -41,7 +41,7 @@ function Header() {
                                 <span class="month-text" id="month-text"></span>
                                 <span>August</span>
                             </div>
-                            <button class="arrow-icon" id="next-month">
+                            <button class="arrow-icon icon-button" id="next-month">
                                 <img src="assets/icons/chevron-right.svg" alt="다음 달">
                             </button>
                         </div>

--- a/src/pages/MainPage/MainPage.css
+++ b/src/pages/MainPage/MainPage.css
@@ -16,16 +16,19 @@
 
 .input-bar label {
     font-weight: 300;
-    font-size: 12px;
+    font-size: 14px;
     margin-bottom: 4px;
     height: 24px;
+    align-items: center;
+    display: flex;
 }
 
 .input-bar input {
-    /* border: none; */
+    border: none;
     outline: none;
     font-weight: 600;
     font-size: 12px;
+    font-family: 'Ownglyph_corncorn-Rg', sans-serif;
 }
 
 .input-count-text {
@@ -39,6 +42,10 @@
     outline: none;
     font-weight: 600;
     font-size: 12px;
+}
+
+.content-field {
+    width: 160px;
 }
 
 .text-align-right {
@@ -59,13 +66,17 @@
 
 .main-page-body {
     padding: 0 24px;
-    background-color: #FFC0CB;
+    /* background-color: #FFC0CB; */
+}
+
+.monthly-income-expense-text span {
+    font-size: 14px;
 }
 
 /* Daily List Styles */
 .daily-list {
     margin-top: 40px;
-    border: 2px solid #4c88ef;
+    /* border: 2px solid #4c88ef; */
 }
 
 .daily-list-content {

--- a/src/pages/MainPage/MainPage.css
+++ b/src/pages/MainPage/MainPage.css
@@ -5,7 +5,6 @@
 .input-bar {
     background-color: #ffffff;
     border: 0.5px solid #000000;
-    z-index: 1;
     transform: translate(0, -50%);
     display: flex;
     justify-content: space-between;

--- a/src/pages/MainPage/components/DailyList.js
+++ b/src/pages/MainPage/components/DailyList.js
@@ -1,6 +1,7 @@
 import DailyListBlock from "../../../components/DailyListBlock/DailyListBlock.js";
+import { formatAmount } from '../../../utils/format.js';
 
-function DailyList({ data }) {
+function DailyList({ data, inputBar, incomeFilterOn, expenseFilterOn }) {
     const list = data.list;
     let selectedId = null;
 
@@ -23,6 +24,9 @@ function DailyList({ data }) {
                 const btn = current.querySelector(".delete-button");
                 if (btn) btn.style.display = "none";
             }
+
+            // InputBar의 입력 필드 초기화
+            inputBar.resetFields();
         } else {
             selectedId = newId;
             const current = document.getElementById(newId);
@@ -31,6 +35,11 @@ function DailyList({ data }) {
                 const btn = current.querySelector(".delete-button");
                 if (btn) btn.style.display = "block";
             }
+
+            // InputBar의 입력 필드에 선택된 데이터 설정
+            const selectedData = list.find(item => item.blockId === newId);
+            inputBar.setFields(selectedData);
+
         }
     };
 
@@ -40,13 +49,17 @@ function DailyList({ data }) {
                 <div class="flex-row">
                     <div class="date-text">${data.date}</div>
                     <div class="inline-block">
-                        ${data.totalIncome !== 0 ? `<span class="mr-1">수입</span><span>${data.totalIncome}원</span>` : ''}
-                        ${data.totalExpenses !== 0 ? `<span class="mr-1">지출</span><span>${data.totalExpenses}원</span>` : ''}
+                        ${data.totalIncome !== 0 ? `<span class="mr-1">수입</span><span class="mr-2">${formatAmount(data.totalIncome)}원</span>` : ''}
+                        ${data.totalExpenses !== 0 ? `<span class="mr-1">지출</span><span>${formatAmount(data.totalExpenses)}원</span>` : ''}
                     </div>
                 </div>
                 <div class="daily-list-content">
                     ${list?.length
-                ? list.map(item =>
+                ? list.filter(item => {
+                    if (item.amount > 0 && !incomeFilterOn) return false;
+                    if (item.amount < 0 && !expenseFilterOn) return false;
+                    return true;
+                }).map(item =>
                     DailyListBlock({ data: item, onSelect: updateSelected }).element
                 ).join('')
                 : ''
@@ -58,8 +71,10 @@ function DailyList({ data }) {
             if (!list || list.length === 0) return;
 
             list.forEach(item => {
-                const dailyListBlock = DailyListBlock({ data: item, onSelect: updateSelected });
-                if (dailyListBlock.init) dailyListBlock.init();
+                if ((item.amount > 0 && incomeFilterOn) || (item.amount < 0 && expenseFilterOn)) {
+                    const dailyListBlock = DailyListBlock({ data: item, onSelect: updateSelected });
+                    if (dailyListBlock.init) dailyListBlock.init();
+                }
             });
         }
     };

--- a/src/pages/MainPage/utils/inputElementUtils.js
+++ b/src/pages/MainPage/utils/inputElementUtils.js
@@ -1,0 +1,10 @@
+export function getInputElements() {
+    return {
+        dateInput: document.getElementById('date-select'),
+        amountInput: document.querySelector('.amount-field'),
+        contentInput: document.querySelector('.content-field'),
+        paymentSelect: document.getElementById('payment-field'),
+        categorySelect: document.getElementById('category-select'),
+        checkButton: document.getElementById('submit-btn'),
+    };
+}

--- a/src/pages/MainPage/utils/validationUtils.js
+++ b/src/pages/MainPage/utils/validationUtils.js
@@ -1,0 +1,31 @@
+import { getInputElements } from './inputElementUtils.js';
+
+export function isInputValid({ dateInput, amountInput, contentInput, paymentSelect, categorySelect }) {
+    return (
+        dateInput.value.trim() !== '' &&
+        !isNaN(parseFloat(amountInput.value)) &&
+        contentInput.value.trim() !== '' &&
+        paymentSelect.value.trim() !== '' &&
+        categorySelect.value.trim() !== ''
+    );
+}
+
+export function updateCheckButtonState(isValid) {
+    const { checkButton } = getInputElements();
+    if (!checkButton) return;
+
+    checkButton.disabled = !isValid;
+    checkButton.classList.toggle('disabled', !isValid);
+    checkButton.style.cursor = isValid ? 'pointer' : 'not-allowed';
+
+    const img = checkButton.querySelector('img');
+    if (img) {
+        img.src = `assets/icons/${isValid ? 'check-button-active' : 'check-button'}.svg`;
+    }
+}
+
+export function validateInputs() {
+    const elements = getInputElements();
+    const isValid = isInputValid(elements);
+    updateCheckButtonState(isValid);
+}

--- a/src/store/incomeExpenseStore.js
+++ b/src/store/incomeExpenseStore.js
@@ -80,30 +80,83 @@ const updateAllDummyData = (newData) => {
 const deleteDailyListBlock = (blockData) => {
     if (!currentIncomeExpenseData) return;
 
-    const listIndex = currentIncomeExpenseData.dailyList.findIndex(item => item.date === blockData.date);
-    if (listIndex === -1) alert('해당 날짜의 데이터가 없습니다.');
-    else {
-        const dailyList = currentIncomeExpenseData.dailyList[listIndex].list;
-        const blockIndex = dailyList.findIndex(item => item.blockId === blockData.blockId);
-        if (blockIndex !== -1) {
-            if (dailyList.length !== 1) {
-                dailyList.splice(blockIndex, 1);
-                // 총액 업데이트
+    const listIndex = currentIncomeExpenseData.dailyList.findIndex(
+        item => item.date === blockData.date
+    );
+    if (listIndex === -1) {
+        alert('해당 날짜의 데이터가 없습니다.');
+        return;
+    }
 
-                if (blockData.amount > 0) {
-                    currentIncomeExpenseData.dailyList[listIndex].totalIncome -= blockData.amount;
-                } else {
-                    currentIncomeExpenseData.dailyList[listIndex].totalExpenses += -blockData.amount;
-                }
-            }
-            else {
-                currentIncomeExpenseData.dailyList.splice(listIndex, 1);
-            }
+    const dailyList = currentIncomeExpenseData.dailyList[listIndex].list;
+    const blockIndex = dailyList.findIndex(item => item.blockId === blockData.blockId);
+    if (blockIndex === -1) {
+        alert('해당 블록이 없습니다.');
+        return;
+    }
+
+    const isOnlyOneBlock = dailyList.length === 1;
+
+    if (isOnlyOneBlock) {
+        currentIncomeExpenseData.dailyList.splice(listIndex, 1);
+    } else {
+        dailyList.splice(blockIndex, 1);
+
+        if (blockData.amount > 0) {
+            currentIncomeExpenseData.dailyList[listIndex].totalIncome -= blockData.amount;
         } else {
-            alert('해당 블록이 없습니다.');
+            currentIncomeExpenseData.dailyList[listIndex].totalExpenses += -blockData.amount;
         }
     }
 };
+
+const updateExistingData = (data, blockId) => {
+    console.log('Updating existing data:', data, 'for blockId:', blockId);
+
+    // blockId를 가진 블록을 찾습니다.
+    const listIndex = currentIncomeExpenseData.dailyList.findIndex(
+        item => item.date === data.date
+    );
+    if (listIndex === -1) {
+        alert('해당 날짜의 데이터가 없습니다.');
+        return;
+    }
+    const dailyList = currentIncomeExpenseData.dailyList[listIndex].list;
+    const blockIndex = dailyList.findIndex(item => item.blockId === blockId);
+    if (blockIndex === -1) {
+        alert('해당 블록이 없습니다.');
+        return;
+    }
+    // 기존 블록 데이터를 업데이트합니다.
+    const existingBlock = dailyList[blockIndex];
+    const oldAmount = existingBlock.amount;
+
+    existingBlock.amount = data.amount;
+    existingBlock.description = data.description;
+    existingBlock.method = data.method;
+    existingBlock.category = data.category;
+    existingBlock.type = data.amount > 0 ? 'income' : 'expense';
+
+    // 금액이 변경되었다면
+    if (oldAmount !== data.amount) {
+        if (data.amount > 0) {
+            currentIncomeExpenseData.dailyList[listIndex].totalIncome += data.amount - oldAmount;
+            console.log('Income updated:', currentIncomeExpenseData.dailyList[listIndex].totalIncome);
+        } else {
+            currentIncomeExpenseData.dailyList[listIndex].totalExpenses += -data.amount - (-oldAmount);
+            console.log('Expenses updated:', currentIncomeExpenseData.dailyList[listIndex].totalExpenses);
+        }
+    }
+    console.log('Updated existing data:', existingBlock);
+    // 변경된 데이터를 저장합니다.
+    allDummyData = allDummyData.map(item => {
+        if (item.year === currentIncomeExpenseData.year && item.month === currentIncomeExpenseData.month) {
+            return currentIncomeExpenseData;
+        }
+        return item;
+    });
+}
+
 
 const incomeExpenseStore = {
     getAllDummyData,
@@ -113,6 +166,7 @@ const incomeExpenseStore = {
     },
     updateAllDummyData,
     deleteDailyListBlock,
+    updateExistingData,
 };
 
 export default incomeExpenseStore;

--- a/src/store/paymentStore.js
+++ b/src/store/paymentStore.js
@@ -1,0 +1,24 @@
+let paymentOriginal = ['현금', '신용카드'];
+let paymentOptions = [...paymentOriginal];
+
+const getPaymentOptions = () => {
+    return paymentOptions;
+}
+
+const addPaymentOption = (option) => {
+    if (!paymentOptions.includes(option)) {
+        paymentOptions.push(option);
+    }
+}
+
+const removePaymentOption = (option) => {
+    paymentOptions = paymentOptions.filter(item => item !== option);
+}
+
+const paymentStore = {
+    getPaymentOptions,
+    addPaymentOption,
+    removePaymentOption
+};
+
+export default paymentStore;


### PR DESCRIPTION
## 완료 작업 목록
### 💰 수입지출내역 수정
- `DailyList`에서 항목 클릭 시 해당 데이터를 `InputBar` 필드에 자동 세팅 (`setFields`)
- 같은 항목을 다시 클릭하면 선택이 해제되며 입력 필드 초기화 (`resetFields`)
- 수정 완료 후 `handleSubmit`을 통해 기존 항목 데이터가 정상적으로 덮어쓰기됨
- 수정 여부는 `isEditing` 상태로 구분하여 분기 처리
- `resetFields()` 호출 시 `isEditing`과 `editingData`가 정상 초기화되도록 개선

### 📊 수입 및 지출 필터링
- `incomeFilterOn`과 `expenseFilterOn` 상태값을 `DailyList`의 파라미터로 전달
- boolean 값에 따라 렌더링 + `init()` 실행 여부 판단

### 🎨전반적인 스타일 적용
- Header 배경색 및 버튼 스타일
- TagBox 카테고리에 따른 `background-color` 맵핑

### 🔽DropDown 컴포넌트 연결


### 💵결제수단 추가 및 삭제 
- `DropDown` 컴포넌트에 파라미터로 `onAdd`, `onDelete` 함수 전달

## 주요 고민과 해결 과정
### ⚠️ isEditing 관련 상태 공유 이슈
**1. 문제**
기존 데이터를 수정한 후 새로운 데이터를 추가하거나 다른 데이터를 수정하면 `isEditing` 값이 비정상적으로 동작함

**2. 원인**
`InputBar()`를 매번 호출하여 새로운 인스턴스가 생성되고, 각 인스턴스는 `isEditing` 상태를 공유하지 않음

**3. 해결 방안**
`InputBar`를 **단일 인스턴스**로 생성하고, 이를 상위 컴포넌트인 `MainPage` 등에서 **재사용**하도록 구조를 개선
  
```js
  // 전역에서 InputBar 한 번만 생성
  const inputBar = InputBar();

  // 이후 여러 컴포넌트에서 주입
  const dailyList = DailyList({ data, inputBar });
```

### 🧩 DropDown 커스텀 컴포넌트 문제

1. DropDown 선택 시 이벤트가 동작하지 않음
- **원인**: `<div>`는 기본적으로 `change` 이벤트를 발생시키지 않음.
- **해결**: 옵션 선택 시 `dispatchEvent(new Event('change'))`를 수동으로 발생시킴.

2. DropDown 값이 외부에서 감지되지 않음
- **원인**: `.value` 속성은 `<div>`에 존재하지 않음.
- **해결**: `dataset.value` 또는 `getAttribute('data-value')`를 통해 값 접근.

### `deleteDailyListBlock` 리팩토링
- 크롱의 피드백로 들여쓰기를 줄여보았다..
- 각 실패 조건에 대해 early return으로 빠르게 종료
- 피드백의 의도대로 반영했는지는 잘 모르겠습니다...

### 금액의 +/- 버튼 누를 때마다 DropDown의 options 변경